### PR TITLE
Fix GitHub spelling

### DIFF
--- a/404.html
+++ b/404.html
@@ -34,7 +34,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you have any suggestions, feedback, or bugs to report, feel free to [open a n
 - [The Japan Times](https://bookclub.japantimes.co.jp/en/), Eri Banno, Yoko Ikeda, Yutaka Ohno, Chikako Shinagawa, and Kyoko Tokashiki for Genki: An Integrated Course in Elementary Japanese.
 - Noriko Udagawa and Reiko Maruyama for some Illustrations that were used.
 - [Patrick Roberts](https://github.com/patrickroberts) for [his help with an algorithm](https://stackoverflow.com/a/59337819/12502093) that helped make mixed kana/kanji answers possible in written quizzes.
-- Everyone who helped contribute to this project, both on Github and outside of it.
+- Everyone who helped contribute to this project, both on GitHub and outside of it.
 
 The following resources were used in this project. Check them out!
 - [Font-Awesome](https://github.com/FortAwesome/Font-Awesome) for the awesome icons.

--- a/donate/index.html
+++ b/donate/index.html
@@ -39,13 +39,13 @@
         <p>Genki Study Resources was created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a>, with the goal of making self-study with the Genki textbooks easier for everyone, for free. As an open source developer, my primary source of income for my works are donations. So if you found this project helpful and would like to support it, please see below for the different ways that you can contribute.</p>
         
         <ul>
-          <li>Buy me a coffee via <a href="https://paypal.me/sethc95/"><strong>Paypal</strong></a>.</li>
+          <li>Buy me a coffee via <a href="https://paypal.me/sethc95/"><strong>PayPal</strong></a>.</li>
           <li>Buy me a gift from my <a href="https://www.amazon.com/hz/wishlist/ls/S7YILFHYK0IZ"><strong>Amazon Wishlist</strong></a>.</li>
         </ul>
         
         <p>You can also support my work in other ways.</p>
         <ul>
-          <li><a href="https://github.com/SethClydesdale/genki-study-resources"><strong>Star the project on Github</strong></a>; Stars show appreciation for a repository maintainer's work.</li>
+          <li><a href="https://github.com/SethClydesdale/genki-study-resources"><strong>Star the project on GitHub</strong></a>; Stars show appreciation for a repository maintainer's work.</li>
           <li>Spread the word about Genki Study Resources; let people know how it helped you or how it can help them!</li>
           <li>Feel free to contact me via one of the platforms located under <a href="https://sethclydesdale.github.io/#main-contact"><strong>"Contact info"</strong></a> to say thanks.</li>
         </ul>
@@ -63,7 +63,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/download/index.html
+++ b/download/index.html
@@ -36,7 +36,7 @@
     <div id="content">
       <div class="content-block">
         <h2 class="title center" id="genki-download">Download</h2>
-        <p>Genki Study Resources was created to aid with self-study, as such you can download it and use it offline anywhere. To download Genki Study Resources for offline use, simply click the download link below to get the latest version from the Github repository.</p>
+        <p>Genki Study Resources was created to aid with self-study, as such you can download it and use it offline anywhere. To download Genki Study Resources for offline use, simply click the download link below to get the latest version from the GitHub repository.</p>
         
         <ul>
           <li><a href="https://github.com/SethClydesdale/genki-study-resources/archive/master.zip"><strong>Download</strong></a></li>
@@ -55,7 +55,7 @@
         <br>
         
         <h3 id="help-and-bugs">Help and Bugs</h3>
-        <p>If you have any issues using Genki Study Resources offline (or online), feel free to let us know by opening a new issue on Github. You can find more information about doing so via the <a href="../report/">report page</a>.</p>
+        <p>If you have any issues using Genki Study Resources offline (or online), feel free to let us know by opening a new issue on GitHub. You can find more information about doing so via the <a href="../report/">report page</a>.</p>
       </div>
     </div>
     
@@ -68,7 +68,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/help/broken-icons/index.html
+++ b/help/broken-icons/index.html
@@ -56,7 +56,7 @@
         
       <div class="content-block">
         <h3 class="section-title" id="install-failed">Icons are Still Broken</h3>
-        <p>If you're still having trouble with the icons not displaying properly, please <a href="https://github.com/SethClydesdale/genki-study-resources/issues">open a new issue on Github</a>, so that we can assist you.</p>
+        <p>If you're still having trouble with the icons not displaying properly, please <a href="https://github.com/SethClydesdale/genki-study-resources/issues">open a new issue on GitHub</a>, so that we can assist you.</p>
       </div>
     </div>
     
@@ -69,7 +69,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/help/dictionaries/index.html
+++ b/help/dictionaries/index.html
@@ -99,7 +99,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/help/index.html
+++ b/help/index.html
@@ -72,7 +72,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/help/stuck-loading/index.html
+++ b/help/stuck-loading/index.html
@@ -59,7 +59,7 @@
         
       <div class="content-block">
         <h3 class="section-title" id="install-failed">Exercises are Still Stuck Loading</h3>
-        <p>If you're still having trouble with the endlessly loading exercises, please <a href="https://github.com/SethClydesdale/genki-study-resources/issues">open a new issue on Github</a>, so that we can assist you.</p>
+        <p>If you're still having trouble with the endlessly loading exercises, please <a href="https://github.com/SethClydesdale/genki-study-resources/issues">open a new issue on GitHub</a>, so that we can assist you.</p>
       </div>
     </div>
     
@@ -72,7 +72,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/help/writing/index.html
+++ b/help/writing/index.html
@@ -119,7 +119,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/index.html
+++ b/index.html
@@ -45,8 +45,8 @@
           <!-- Updates HERE -->
           <!--<div class="announcement announce-hidden"><span class="date">00/00/00</span></div>-->
           <!-- Default Tips/Info -->
-          <div class="announcement">Looking for more self-study resources? Visit the official <a href="http://genki.japantimes.co.jp/self_en">self-study room</a> for Genki or check out some of the featured links in the <a href="https://github.com/SethClydesdale/genki-study-resources#additional-links-for-studying-japanese">readme</a> on Github.</div>
-          <div class="announcement announce-hidden">Have a question about the site? Check out the <a href="help/">FAQ</a>! If you can't find an answer to your question, feel free to contact us via <a href="https://github.com/SethClydesdale/genki-study-resources/issues">Github's issues</a> and we'll try to answer your question in a timely manner.</div>
+          <div class="announcement">Looking for more self-study resources? Visit the official <a href="http://genki.japantimes.co.jp/self_en">self-study room</a> for Genki or check out some of the featured links in the <a href="https://github.com/SethClydesdale/genki-study-resources#additional-links-for-studying-japanese">readme</a> on GitHub.</div>
+          <div class="announcement announce-hidden">Have a question about the site? Check out the <a href="help/">FAQ</a>! If you can't find an answer to your question, feel free to contact us via <a href="https://github.com/SethClydesdale/genki-study-resources/issues">GitHub's issues</a> and we'll try to answer your question in a timely manner.</div>
           <div class="announcement announce-hidden">Find a bug or mistake on the site? Want to submit a suggestion or give us feedback? Check out the <a href="report/">report page</a> for more information. We'd love to hear from you!</div>
           <div class="announcement announce-hidden">Don't have a network connection all the time? Genki Study Resources can be used offline as well! Head on over to the <a href="download/">download page</a> to get the latest release.</div>
           <div class="announcement announce-hidden">If you found this tool helpful during your studies, please consider making <a href="donate/">a donation</a> to help support my work. Thank you!</div>
@@ -64,7 +64,7 @@
           <span><a id="link-report" href="report/"><i class="fa">&#xf188;</i>Bug Reports &amp; Feedback</a></span>
           <span><a id="link-download" href="download/"><i class="fa">&#xf019;</i>Download</a></span>
           <span><a id="link-donate" href="donate/"><i class="fa">&#xf004;</i>Donate</a></span>
-          <span><a id="link-github" href="https://github.com/SethClydesdale/genki-study-resources"><i class="fa">&#xf09b;</i>Github Repo</a></span>
+          <span><a id="link-github" href="https://github.com/SethClydesdale/genki-study-resources"><i class="fa">&#xf09b;</i>GitHub Repo</a></span>
         </div>
         <br>
         
@@ -1433,7 +1433,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
   

--- a/lessons/appendix/conjugation-chart/index.html
+++ b/lessons/appendix/conjugation-chart/index.html
@@ -391,7 +391,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/appendix/dictionary/index.html
+++ b/lessons/appendix/dictionary/index.html
@@ -951,7 +951,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/appendix/map-of-japan/index.html
+++ b/lessons/appendix/map-of-japan/index.html
@@ -72,7 +72,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/appendix/numbers-chart/index.html
+++ b/lessons/appendix/numbers-chart/index.html
@@ -440,7 +440,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-0/culture-1/index.html
+++ b/lessons/lesson-0/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-0/greetings-practice/index.html
+++ b/lessons/lesson-0/greetings-practice/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-0/greetings/index.html
+++ b/lessons/lesson-0/greetings/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-0/hiragana-1/index.html
+++ b/lessons/lesson-0/hiragana-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-0/hiragana-2/index.html
+++ b/lessons/lesson-0/hiragana-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-0/hiragana-3/index.html
+++ b/lessons/lesson-0/hiragana-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-0/hiragana-4/index.html
+++ b/lessons/lesson-0/hiragana-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-0/katakana-1/index.html
+++ b/lessons/lesson-0/katakana-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-0/katakana-2/index.html
+++ b/lessons/lesson-0/katakana-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-0/katakana-3/index.html
+++ b/lessons/lesson-0/katakana-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-0/katakana-4/index.html
+++ b/lessons/lesson-0/katakana-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-0/katakana-5/index.html
+++ b/lessons/lesson-0/katakana-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-0/match-1/index.html
+++ b/lessons/lesson-0/match-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-0/workbook-1/index.html
+++ b/lessons/lesson-0/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/age-1/index.html
+++ b/lessons/lesson-1/age-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/culture-1/index.html
+++ b/lessons/lesson-1/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/grammar-1/index.html
+++ b/lessons/lesson-1/grammar-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/grammar-2/index.html
+++ b/lessons/lesson-1/grammar-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/grammar-3/index.html
+++ b/lessons/lesson-1/grammar-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/grammar-4/index.html
+++ b/lessons/lesson-1/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/grammar-5/index.html
+++ b/lessons/lesson-1/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/literacy-1/index.html
+++ b/lessons/lesson-1/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/literacy-2/index.html
+++ b/lessons/lesson-1/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/literacy-3/index.html
+++ b/lessons/lesson-1/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/literacy-4/index.html
+++ b/lessons/lesson-1/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/literacy-5/index.html
+++ b/lessons/lesson-1/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/literacy-6/index.html
+++ b/lessons/lesson-1/literacy-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/literacy-wb-1/index.html
+++ b/lessons/lesson-1/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/literacy-wb-10/index.html
+++ b/lessons/lesson-1/literacy-wb-10/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/literacy-wb-11/index.html
+++ b/lessons/lesson-1/literacy-wb-11/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/literacy-wb-12/index.html
+++ b/lessons/lesson-1/literacy-wb-12/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/literacy-wb-13/index.html
+++ b/lessons/lesson-1/literacy-wb-13/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/literacy-wb-14/index.html
+++ b/lessons/lesson-1/literacy-wb-14/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/literacy-wb-2/index.html
+++ b/lessons/lesson-1/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/literacy-wb-3/index.html
+++ b/lessons/lesson-1/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/literacy-wb-4/index.html
+++ b/lessons/lesson-1/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/literacy-wb-5/index.html
+++ b/lessons/lesson-1/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/literacy-wb-6/index.html
+++ b/lessons/lesson-1/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/literacy-wb-7/index.html
+++ b/lessons/lesson-1/literacy-wb-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/literacy-wb-8/index.html
+++ b/lessons/lesson-1/literacy-wb-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/literacy-wb-9/index.html
+++ b/lessons/lesson-1/literacy-wb-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/numbers-1/index.html
+++ b/lessons/lesson-1/numbers-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/numbers-2/index.html
+++ b/lessons/lesson-1/numbers-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/numbers-3/index.html
+++ b/lessons/lesson-1/numbers-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/phone-1/index.html
+++ b/lessons/lesson-1/phone-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/time-1/index.html
+++ b/lessons/lesson-1/time-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/time-2/index.html
+++ b/lessons/lesson-1/time-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/time-3/index.html
+++ b/lessons/lesson-1/time-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/vocab-1/index.html
+++ b/lessons/lesson-1/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/vocab-2/index.html
+++ b/lessons/lesson-1/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/vocab-3/index.html
+++ b/lessons/lesson-1/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/vocab-4/index.html
+++ b/lessons/lesson-1/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/vocab-5/index.html
+++ b/lessons/lesson-1/vocab-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/vocab-6/index.html
+++ b/lessons/lesson-1/vocab-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/vocab-7/index.html
+++ b/lessons/lesson-1/vocab-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/workbook-1/index.html
+++ b/lessons/lesson-1/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/workbook-2/index.html
+++ b/lessons/lesson-1/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/workbook-3/index.html
+++ b/lessons/lesson-1/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/workbook-4/index.html
+++ b/lessons/lesson-1/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/workbook-5/index.html
+++ b/lessons/lesson-1/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/workbook-6/index.html
+++ b/lessons/lesson-1/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/workbook-7/index.html
+++ b/lessons/lesson-1/workbook-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/workbook-8/index.html
+++ b/lessons/lesson-1/workbook-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-1/workbook-9/index.html
+++ b/lessons/lesson-1/workbook-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/culture-1/index.html
+++ b/lessons/lesson-10/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/grammar-1/index.html
+++ b/lessons/lesson-10/grammar-1/index.html
@@ -54,7 +54,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/grammar-2/index.html
+++ b/lessons/lesson-10/grammar-2/index.html
@@ -54,7 +54,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/grammar-3/index.html
+++ b/lessons/lesson-10/grammar-3/index.html
@@ -54,7 +54,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/grammar-4/index.html
+++ b/lessons/lesson-10/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/grammar-5/index.html
+++ b/lessons/lesson-10/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/grammar-6/index.html
+++ b/lessons/lesson-10/grammar-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/grammar-7/index.html
+++ b/lessons/lesson-10/grammar-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/grammar-8/index.html
+++ b/lessons/lesson-10/grammar-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/literacy-1/index.html
+++ b/lessons/lesson-10/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/literacy-2/index.html
+++ b/lessons/lesson-10/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/literacy-3/index.html
+++ b/lessons/lesson-10/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/literacy-4/index.html
+++ b/lessons/lesson-10/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/literacy-5/index.html
+++ b/lessons/lesson-10/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/literacy-6/index.html
+++ b/lessons/lesson-10/literacy-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/literacy-7/index.html
+++ b/lessons/lesson-10/literacy-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/literacy-8/index.html
+++ b/lessons/lesson-10/literacy-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/literacy-wb-1/index.html
+++ b/lessons/lesson-10/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/literacy-wb-2/index.html
+++ b/lessons/lesson-10/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/literacy-wb-3/index.html
+++ b/lessons/lesson-10/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/literacy-wb-4/index.html
+++ b/lessons/lesson-10/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/literacy-wb-5/index.html
+++ b/lessons/lesson-10/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/literacy-wb-6/index.html
+++ b/lessons/lesson-10/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/literacy-wb-7/index.html
+++ b/lessons/lesson-10/literacy-wb-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/vocab-1/index.html
+++ b/lessons/lesson-10/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/vocab-2/index.html
+++ b/lessons/lesson-10/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/vocab-3/index.html
+++ b/lessons/lesson-10/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/vocab-4/index.html
+++ b/lessons/lesson-10/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/vocab-5/index.html
+++ b/lessons/lesson-10/vocab-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/vocab-6/index.html
+++ b/lessons/lesson-10/vocab-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/vocab-7/index.html
+++ b/lessons/lesson-10/vocab-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/vocab-8/index.html
+++ b/lessons/lesson-10/vocab-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/workbook-1/index.html
+++ b/lessons/lesson-10/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/workbook-2/index.html
+++ b/lessons/lesson-10/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/workbook-3/index.html
+++ b/lessons/lesson-10/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/workbook-4/index.html
+++ b/lessons/lesson-10/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/workbook-5/index.html
+++ b/lessons/lesson-10/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/workbook-6/index.html
+++ b/lessons/lesson-10/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/workbook-7/index.html
+++ b/lessons/lesson-10/workbook-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-10/workbook-8/index.html
+++ b/lessons/lesson-10/workbook-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/culture-1/index.html
+++ b/lessons/lesson-11/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/grammar-1/index.html
+++ b/lessons/lesson-11/grammar-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/grammar-2/index.html
+++ b/lessons/lesson-11/grammar-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/grammar-3/index.html
+++ b/lessons/lesson-11/grammar-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/grammar-4/index.html
+++ b/lessons/lesson-11/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/grammar-5/index.html
+++ b/lessons/lesson-11/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/literacy-1/index.html
+++ b/lessons/lesson-11/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/literacy-2/index.html
+++ b/lessons/lesson-11/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/literacy-3/index.html
+++ b/lessons/lesson-11/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/literacy-4/index.html
+++ b/lessons/lesson-11/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/literacy-5/index.html
+++ b/lessons/lesson-11/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/literacy-6/index.html
+++ b/lessons/lesson-11/literacy-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/literacy-7/index.html
+++ b/lessons/lesson-11/literacy-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/literacy-wb-1/index.html
+++ b/lessons/lesson-11/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/literacy-wb-2/index.html
+++ b/lessons/lesson-11/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/literacy-wb-3/index.html
+++ b/lessons/lesson-11/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/literacy-wb-4/index.html
+++ b/lessons/lesson-11/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/literacy-wb-5/index.html
+++ b/lessons/lesson-11/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/literacy-wb-6/index.html
+++ b/lessons/lesson-11/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/literacy-wb-7/index.html
+++ b/lessons/lesson-11/literacy-wb-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/vocab-1/index.html
+++ b/lessons/lesson-11/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/vocab-2/index.html
+++ b/lessons/lesson-11/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/vocab-3/index.html
+++ b/lessons/lesson-11/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/vocab-4/index.html
+++ b/lessons/lesson-11/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/vocab-5/index.html
+++ b/lessons/lesson-11/vocab-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/vocab-6/index.html
+++ b/lessons/lesson-11/vocab-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/vocab-7/index.html
+++ b/lessons/lesson-11/vocab-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/vocab-8/index.html
+++ b/lessons/lesson-11/vocab-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/workbook-1/index.html
+++ b/lessons/lesson-11/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/workbook-2/index.html
+++ b/lessons/lesson-11/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/workbook-3/index.html
+++ b/lessons/lesson-11/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/workbook-4/index.html
+++ b/lessons/lesson-11/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/workbook-5/index.html
+++ b/lessons/lesson-11/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-11/workbook-6/index.html
+++ b/lessons/lesson-11/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/culture-1/index.html
+++ b/lessons/lesson-12/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/grammar-1/index.html
+++ b/lessons/lesson-12/grammar-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/grammar-2/index.html
+++ b/lessons/lesson-12/grammar-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/grammar-3/index.html
+++ b/lessons/lesson-12/grammar-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/grammar-4/index.html
+++ b/lessons/lesson-12/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/grammar-5/index.html
+++ b/lessons/lesson-12/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/grammar-6/index.html
+++ b/lessons/lesson-12/grammar-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/grammar-7/index.html
+++ b/lessons/lesson-12/grammar-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/grammar-8/index.html
+++ b/lessons/lesson-12/grammar-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/literacy-1/index.html
+++ b/lessons/lesson-12/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/literacy-2/index.html
+++ b/lessons/lesson-12/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/literacy-3/index.html
+++ b/lessons/lesson-12/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/literacy-4/index.html
+++ b/lessons/lesson-12/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/literacy-5/index.html
+++ b/lessons/lesson-12/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/literacy-6/index.html
+++ b/lessons/lesson-12/literacy-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/literacy-7/index.html
+++ b/lessons/lesson-12/literacy-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/literacy-wb-1/index.html
+++ b/lessons/lesson-12/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/literacy-wb-2/index.html
+++ b/lessons/lesson-12/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/literacy-wb-3/index.html
+++ b/lessons/lesson-12/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/literacy-wb-4/index.html
+++ b/lessons/lesson-12/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/literacy-wb-5/index.html
+++ b/lessons/lesson-12/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/literacy-wb-6/index.html
+++ b/lessons/lesson-12/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/literacy-wb-7/index.html
+++ b/lessons/lesson-12/literacy-wb-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/vocab-1/index.html
+++ b/lessons/lesson-12/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/vocab-2/index.html
+++ b/lessons/lesson-12/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/vocab-3/index.html
+++ b/lessons/lesson-12/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/vocab-4/index.html
+++ b/lessons/lesson-12/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/vocab-5/index.html
+++ b/lessons/lesson-12/vocab-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/vocab-6/index.html
+++ b/lessons/lesson-12/vocab-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/vocab-7/index.html
+++ b/lessons/lesson-12/vocab-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/workbook-1/index.html
+++ b/lessons/lesson-12/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/workbook-2/index.html
+++ b/lessons/lesson-12/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/workbook-3/index.html
+++ b/lessons/lesson-12/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/workbook-4/index.html
+++ b/lessons/lesson-12/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/workbook-5/index.html
+++ b/lessons/lesson-12/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/workbook-6/index.html
+++ b/lessons/lesson-12/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/workbook-7/index.html
+++ b/lessons/lesson-12/workbook-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-12/workbook-8/index.html
+++ b/lessons/lesson-12/workbook-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/culture-1/index.html
+++ b/lessons/lesson-13/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/culture-2/index.html
+++ b/lessons/lesson-13/culture-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/grammar-1/index.html
+++ b/lessons/lesson-13/grammar-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/grammar-2/index.html
+++ b/lessons/lesson-13/grammar-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/grammar-3/index.html
+++ b/lessons/lesson-13/grammar-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/grammar-4/index.html
+++ b/lessons/lesson-13/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/grammar-5/index.html
+++ b/lessons/lesson-13/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/grammar-6/index.html
+++ b/lessons/lesson-13/grammar-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/grammar-7/index.html
+++ b/lessons/lesson-13/grammar-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/grammar-8/index.html
+++ b/lessons/lesson-13/grammar-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/grammar-9/index.html
+++ b/lessons/lesson-13/grammar-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/literacy-1/index.html
+++ b/lessons/lesson-13/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/literacy-2/index.html
+++ b/lessons/lesson-13/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/literacy-3/index.html
+++ b/lessons/lesson-13/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/literacy-4/index.html
+++ b/lessons/lesson-13/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/literacy-5/index.html
+++ b/lessons/lesson-13/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/literacy-6/index.html
+++ b/lessons/lesson-13/literacy-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/literacy-7/index.html
+++ b/lessons/lesson-13/literacy-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/literacy-8/index.html
+++ b/lessons/lesson-13/literacy-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/literacy-9/index.html
+++ b/lessons/lesson-13/literacy-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/literacy-wb-1/index.html
+++ b/lessons/lesson-13/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/literacy-wb-2/index.html
+++ b/lessons/lesson-13/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/literacy-wb-3/index.html
+++ b/lessons/lesson-13/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/literacy-wb-4/index.html
+++ b/lessons/lesson-13/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/literacy-wb-5/index.html
+++ b/lessons/lesson-13/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/literacy-wb-6/index.html
+++ b/lessons/lesson-13/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/vocab-1/index.html
+++ b/lessons/lesson-13/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/vocab-2/index.html
+++ b/lessons/lesson-13/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/vocab-3/index.html
+++ b/lessons/lesson-13/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/vocab-4/index.html
+++ b/lessons/lesson-13/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/vocab-5/index.html
+++ b/lessons/lesson-13/vocab-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/vocab-6/index.html
+++ b/lessons/lesson-13/vocab-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/vocab-7/index.html
+++ b/lessons/lesson-13/vocab-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/vocab-8/index.html
+++ b/lessons/lesson-13/vocab-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/workbook-1/index.html
+++ b/lessons/lesson-13/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/workbook-10/index.html
+++ b/lessons/lesson-13/workbook-10/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/workbook-2/index.html
+++ b/lessons/lesson-13/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/workbook-3/index.html
+++ b/lessons/lesson-13/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/workbook-4/index.html
+++ b/lessons/lesson-13/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/workbook-5/index.html
+++ b/lessons/lesson-13/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/workbook-6/index.html
+++ b/lessons/lesson-13/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/workbook-7/index.html
+++ b/lessons/lesson-13/workbook-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/workbook-8/index.html
+++ b/lessons/lesson-13/workbook-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-13/workbook-9/index.html
+++ b/lessons/lesson-13/workbook-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/culture-1/index.html
+++ b/lessons/lesson-14/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/grammar-1/index.html
+++ b/lessons/lesson-14/grammar-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/grammar-2/index.html
+++ b/lessons/lesson-14/grammar-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/grammar-3/index.html
+++ b/lessons/lesson-14/grammar-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/grammar-4/index.html
+++ b/lessons/lesson-14/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/grammar-5/index.html
+++ b/lessons/lesson-14/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/grammar-6/index.html
+++ b/lessons/lesson-14/grammar-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/grammar-7/index.html
+++ b/lessons/lesson-14/grammar-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/grammar-8/index.html
+++ b/lessons/lesson-14/grammar-8/index.html
@@ -54,7 +54,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/grammar-9/index.html
+++ b/lessons/lesson-14/grammar-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/literacy-1/index.html
+++ b/lessons/lesson-14/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/literacy-2/index.html
+++ b/lessons/lesson-14/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/literacy-3/index.html
+++ b/lessons/lesson-14/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/literacy-4/index.html
+++ b/lessons/lesson-14/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/literacy-5/index.html
+++ b/lessons/lesson-14/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/literacy-6/index.html
+++ b/lessons/lesson-14/literacy-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/literacy-7/index.html
+++ b/lessons/lesson-14/literacy-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/literacy-wb-1/index.html
+++ b/lessons/lesson-14/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/literacy-wb-2/index.html
+++ b/lessons/lesson-14/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/literacy-wb-3/index.html
+++ b/lessons/lesson-14/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/literacy-wb-4/index.html
+++ b/lessons/lesson-14/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/literacy-wb-5/index.html
+++ b/lessons/lesson-14/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/literacy-wb-6/index.html
+++ b/lessons/lesson-14/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/vocab-1/index.html
+++ b/lessons/lesson-14/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/vocab-2/index.html
+++ b/lessons/lesson-14/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/vocab-3/index.html
+++ b/lessons/lesson-14/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/vocab-4/index.html
+++ b/lessons/lesson-14/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/vocab-5/index.html
+++ b/lessons/lesson-14/vocab-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/vocab-6/index.html
+++ b/lessons/lesson-14/vocab-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/workbook-1/index.html
+++ b/lessons/lesson-14/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/workbook-2/index.html
+++ b/lessons/lesson-14/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/workbook-3/index.html
+++ b/lessons/lesson-14/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/workbook-4/index.html
+++ b/lessons/lesson-14/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/workbook-5/index.html
+++ b/lessons/lesson-14/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/workbook-6/index.html
+++ b/lessons/lesson-14/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-14/workbook-7/index.html
+++ b/lessons/lesson-14/workbook-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/culture-1/index.html
+++ b/lessons/lesson-15/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/grammar-1/index.html
+++ b/lessons/lesson-15/grammar-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/grammar-2/index.html
+++ b/lessons/lesson-15/grammar-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/grammar-3/index.html
+++ b/lessons/lesson-15/grammar-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/grammar-4/index.html
+++ b/lessons/lesson-15/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/grammar-5/index.html
+++ b/lessons/lesson-15/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/grammar-6/index.html
+++ b/lessons/lesson-15/grammar-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/grammar-7/index.html
+++ b/lessons/lesson-15/grammar-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/literacy-1/index.html
+++ b/lessons/lesson-15/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/literacy-2/index.html
+++ b/lessons/lesson-15/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/literacy-3/index.html
+++ b/lessons/lesson-15/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/literacy-4/index.html
+++ b/lessons/lesson-15/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/literacy-5/index.html
+++ b/lessons/lesson-15/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/literacy-6/index.html
+++ b/lessons/lesson-15/literacy-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/literacy-7/index.html
+++ b/lessons/lesson-15/literacy-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/literacy-wb-1/index.html
+++ b/lessons/lesson-15/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/literacy-wb-2/index.html
+++ b/lessons/lesson-15/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/literacy-wb-3/index.html
+++ b/lessons/lesson-15/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/literacy-wb-4/index.html
+++ b/lessons/lesson-15/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/literacy-wb-5/index.html
+++ b/lessons/lesson-15/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/literacy-wb-6/index.html
+++ b/lessons/lesson-15/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/vocab-1/index.html
+++ b/lessons/lesson-15/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/vocab-2/index.html
+++ b/lessons/lesson-15/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/vocab-3/index.html
+++ b/lessons/lesson-15/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/vocab-4/index.html
+++ b/lessons/lesson-15/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/vocab-5/index.html
+++ b/lessons/lesson-15/vocab-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/vocab-6/index.html
+++ b/lessons/lesson-15/vocab-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/workbook-1/index.html
+++ b/lessons/lesson-15/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/workbook-2/index.html
+++ b/lessons/lesson-15/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/workbook-3/index.html
+++ b/lessons/lesson-15/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/workbook-4/index.html
+++ b/lessons/lesson-15/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/workbook-5/index.html
+++ b/lessons/lesson-15/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/workbook-6/index.html
+++ b/lessons/lesson-15/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/workbook-7/index.html
+++ b/lessons/lesson-15/workbook-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-15/workbook-8/index.html
+++ b/lessons/lesson-15/workbook-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/culture-1/index.html
+++ b/lessons/lesson-16/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/grammar-1/index.html
+++ b/lessons/lesson-16/grammar-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/grammar-2/index.html
+++ b/lessons/lesson-16/grammar-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/grammar-3/index.html
+++ b/lessons/lesson-16/grammar-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/grammar-4/index.html
+++ b/lessons/lesson-16/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/grammar-5/index.html
+++ b/lessons/lesson-16/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/grammar-6/index.html
+++ b/lessons/lesson-16/grammar-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/grammar-7/index.html
+++ b/lessons/lesson-16/grammar-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/grammar-8/index.html
+++ b/lessons/lesson-16/grammar-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/grammar-9/index.html
+++ b/lessons/lesson-16/grammar-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/literacy-1/index.html
+++ b/lessons/lesson-16/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/literacy-2/index.html
+++ b/lessons/lesson-16/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/literacy-3/index.html
+++ b/lessons/lesson-16/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/literacy-4/index.html
+++ b/lessons/lesson-16/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/literacy-5/index.html
+++ b/lessons/lesson-16/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/literacy-6/index.html
+++ b/lessons/lesson-16/literacy-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/literacy-7/index.html
+++ b/lessons/lesson-16/literacy-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/literacy-wb-1/index.html
+++ b/lessons/lesson-16/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/literacy-wb-2/index.html
+++ b/lessons/lesson-16/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/literacy-wb-3/index.html
+++ b/lessons/lesson-16/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/literacy-wb-4/index.html
+++ b/lessons/lesson-16/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/literacy-wb-5/index.html
+++ b/lessons/lesson-16/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/literacy-wb-6/index.html
+++ b/lessons/lesson-16/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/vocab-1/index.html
+++ b/lessons/lesson-16/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/vocab-2/index.html
+++ b/lessons/lesson-16/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/vocab-3/index.html
+++ b/lessons/lesson-16/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/vocab-4/index.html
+++ b/lessons/lesson-16/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/workbook-1/index.html
+++ b/lessons/lesson-16/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/workbook-2/index.html
+++ b/lessons/lesson-16/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/workbook-3/index.html
+++ b/lessons/lesson-16/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/workbook-4/index.html
+++ b/lessons/lesson-16/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/workbook-5/index.html
+++ b/lessons/lesson-16/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/workbook-6/index.html
+++ b/lessons/lesson-16/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/workbook-7/index.html
+++ b/lessons/lesson-16/workbook-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/workbook-8/index.html
+++ b/lessons/lesson-16/workbook-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-16/workbook-9/index.html
+++ b/lessons/lesson-16/workbook-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/culture-1/index.html
+++ b/lessons/lesson-17/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/grammar-1/index.html
+++ b/lessons/lesson-17/grammar-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/grammar-2/index.html
+++ b/lessons/lesson-17/grammar-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/grammar-3/index.html
+++ b/lessons/lesson-17/grammar-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/grammar-4/index.html
+++ b/lessons/lesson-17/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/grammar-5/index.html
+++ b/lessons/lesson-17/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/grammar-6/index.html
+++ b/lessons/lesson-17/grammar-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/grammar-7/index.html
+++ b/lessons/lesson-17/grammar-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/grammar-8/index.html
+++ b/lessons/lesson-17/grammar-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/literacy-1/index.html
+++ b/lessons/lesson-17/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/literacy-2/index.html
+++ b/lessons/lesson-17/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/literacy-3/index.html
+++ b/lessons/lesson-17/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/literacy-4/index.html
+++ b/lessons/lesson-17/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/literacy-5/index.html
+++ b/lessons/lesson-17/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/literacy-6/index.html
+++ b/lessons/lesson-17/literacy-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/literacy-7/index.html
+++ b/lessons/lesson-17/literacy-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/literacy-wb-1/index.html
+++ b/lessons/lesson-17/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/literacy-wb-2/index.html
+++ b/lessons/lesson-17/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/literacy-wb-3/index.html
+++ b/lessons/lesson-17/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/literacy-wb-4/index.html
+++ b/lessons/lesson-17/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/literacy-wb-5/index.html
+++ b/lessons/lesson-17/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/literacy-wb-6/index.html
+++ b/lessons/lesson-17/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/vocab-1/index.html
+++ b/lessons/lesson-17/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/vocab-2/index.html
+++ b/lessons/lesson-17/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/vocab-3/index.html
+++ b/lessons/lesson-17/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/vocab-4/index.html
+++ b/lessons/lesson-17/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/vocab-5/index.html
+++ b/lessons/lesson-17/vocab-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/vocab-6/index.html
+++ b/lessons/lesson-17/vocab-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/vocab-7/index.html
+++ b/lessons/lesson-17/vocab-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/workbook-1/index.html
+++ b/lessons/lesson-17/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/workbook-2/index.html
+++ b/lessons/lesson-17/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/workbook-3/index.html
+++ b/lessons/lesson-17/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/workbook-4/index.html
+++ b/lessons/lesson-17/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/workbook-5/index.html
+++ b/lessons/lesson-17/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/workbook-6/index.html
+++ b/lessons/lesson-17/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-17/workbook-7/index.html
+++ b/lessons/lesson-17/workbook-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/culture-1/index.html
+++ b/lessons/lesson-18/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/culture-2/index.html
+++ b/lessons/lesson-18/culture-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/grammar-1/index.html
+++ b/lessons/lesson-18/grammar-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/grammar-2/index.html
+++ b/lessons/lesson-18/grammar-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/grammar-3/index.html
+++ b/lessons/lesson-18/grammar-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/grammar-4/index.html
+++ b/lessons/lesson-18/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/grammar-5/index.html
+++ b/lessons/lesson-18/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/grammar-6/index.html
+++ b/lessons/lesson-18/grammar-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/grammar-7/index.html
+++ b/lessons/lesson-18/grammar-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/grammar-8/index.html
+++ b/lessons/lesson-18/grammar-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/grammar-9/index.html
+++ b/lessons/lesson-18/grammar-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/literacy-1/index.html
+++ b/lessons/lesson-18/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/literacy-2/index.html
+++ b/lessons/lesson-18/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/literacy-3/index.html
+++ b/lessons/lesson-18/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/literacy-4/index.html
+++ b/lessons/lesson-18/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/literacy-5/index.html
+++ b/lessons/lesson-18/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/literacy-6/index.html
+++ b/lessons/lesson-18/literacy-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/literacy-7/index.html
+++ b/lessons/lesson-18/literacy-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/literacy-8/index.html
+++ b/lessons/lesson-18/literacy-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/literacy-wb-1/index.html
+++ b/lessons/lesson-18/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/literacy-wb-2/index.html
+++ b/lessons/lesson-18/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/literacy-wb-3/index.html
+++ b/lessons/lesson-18/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/literacy-wb-4/index.html
+++ b/lessons/lesson-18/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/literacy-wb-5/index.html
+++ b/lessons/lesson-18/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/literacy-wb-6/index.html
+++ b/lessons/lesson-18/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/vocab-1/index.html
+++ b/lessons/lesson-18/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/vocab-2/index.html
+++ b/lessons/lesson-18/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/vocab-3/index.html
+++ b/lessons/lesson-18/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/vocab-4/index.html
+++ b/lessons/lesson-18/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/vocab-5/index.html
+++ b/lessons/lesson-18/vocab-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/vocab-6/index.html
+++ b/lessons/lesson-18/vocab-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/workbook-0/index.html
+++ b/lessons/lesson-18/workbook-0/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/workbook-1/index.html
+++ b/lessons/lesson-18/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/workbook-2/index.html
+++ b/lessons/lesson-18/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/workbook-3/index.html
+++ b/lessons/lesson-18/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/workbook-4/index.html
+++ b/lessons/lesson-18/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/workbook-5/index.html
+++ b/lessons/lesson-18/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/workbook-6/index.html
+++ b/lessons/lesson-18/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/workbook-7/index.html
+++ b/lessons/lesson-18/workbook-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-18/workbook-8/index.html
+++ b/lessons/lesson-18/workbook-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/culture-1/index.html
+++ b/lessons/lesson-19/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/grammar-1/index.html
+++ b/lessons/lesson-19/grammar-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/grammar-2/index.html
+++ b/lessons/lesson-19/grammar-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/grammar-3/index.html
+++ b/lessons/lesson-19/grammar-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/grammar-4/index.html
+++ b/lessons/lesson-19/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/grammar-5/index.html
+++ b/lessons/lesson-19/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/grammar-6/index.html
+++ b/lessons/lesson-19/grammar-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/grammar-7/index.html
+++ b/lessons/lesson-19/grammar-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/grammar-8/index.html
+++ b/lessons/lesson-19/grammar-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/literacy-1/index.html
+++ b/lessons/lesson-19/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/literacy-2/index.html
+++ b/lessons/lesson-19/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/literacy-3/index.html
+++ b/lessons/lesson-19/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/literacy-4/index.html
+++ b/lessons/lesson-19/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/literacy-5/index.html
+++ b/lessons/lesson-19/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/literacy-6/index.html
+++ b/lessons/lesson-19/literacy-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/literacy-7/index.html
+++ b/lessons/lesson-19/literacy-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/literacy-8/index.html
+++ b/lessons/lesson-19/literacy-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/literacy-9/index.html
+++ b/lessons/lesson-19/literacy-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/literacy-wb-1/index.html
+++ b/lessons/lesson-19/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/literacy-wb-2/index.html
+++ b/lessons/lesson-19/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/literacy-wb-3/index.html
+++ b/lessons/lesson-19/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/literacy-wb-4/index.html
+++ b/lessons/lesson-19/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/literacy-wb-5/index.html
+++ b/lessons/lesson-19/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/literacy-wb-6/index.html
+++ b/lessons/lesson-19/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/vocab-1/index.html
+++ b/lessons/lesson-19/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/vocab-2/index.html
+++ b/lessons/lesson-19/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/vocab-3/index.html
+++ b/lessons/lesson-19/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/vocab-4/index.html
+++ b/lessons/lesson-19/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/vocab-5/index.html
+++ b/lessons/lesson-19/vocab-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/workbook-1/index.html
+++ b/lessons/lesson-19/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/workbook-2/index.html
+++ b/lessons/lesson-19/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/workbook-3/index.html
+++ b/lessons/lesson-19/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/workbook-4/index.html
+++ b/lessons/lesson-19/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/workbook-5/index.html
+++ b/lessons/lesson-19/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/workbook-6/index.html
+++ b/lessons/lesson-19/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/workbook-7/index.html
+++ b/lessons/lesson-19/workbook-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-19/workbook-8/index.html
+++ b/lessons/lesson-19/workbook-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/culture-1/index.html
+++ b/lessons/lesson-2/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/grammar-1/index.html
+++ b/lessons/lesson-2/grammar-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/grammar-2/index.html
+++ b/lessons/lesson-2/grammar-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/grammar-3/index.html
+++ b/lessons/lesson-2/grammar-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/grammar-4/index.html
+++ b/lessons/lesson-2/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/grammar-5/index.html
+++ b/lessons/lesson-2/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/grammar-6/index.html
+++ b/lessons/lesson-2/grammar-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/literacy-1/index.html
+++ b/lessons/lesson-2/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/literacy-2/index.html
+++ b/lessons/lesson-2/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/literacy-3/index.html
+++ b/lessons/lesson-2/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/literacy-4/index.html
+++ b/lessons/lesson-2/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/literacy-5/index.html
+++ b/lessons/lesson-2/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/literacy-wb-1/index.html
+++ b/lessons/lesson-2/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/literacy-wb-10/index.html
+++ b/lessons/lesson-2/literacy-wb-10/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/literacy-wb-2/index.html
+++ b/lessons/lesson-2/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/literacy-wb-3/index.html
+++ b/lessons/lesson-2/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/literacy-wb-4/index.html
+++ b/lessons/lesson-2/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/literacy-wb-5/index.html
+++ b/lessons/lesson-2/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/literacy-wb-6/index.html
+++ b/lessons/lesson-2/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/literacy-wb-7/index.html
+++ b/lessons/lesson-2/literacy-wb-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/literacy-wb-8/index.html
+++ b/lessons/lesson-2/literacy-wb-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/literacy-wb-9/index.html
+++ b/lessons/lesson-2/literacy-wb-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/numbers-1/index.html
+++ b/lessons/lesson-2/numbers-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/numbers-2/index.html
+++ b/lessons/lesson-2/numbers-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/numbers-3/index.html
+++ b/lessons/lesson-2/numbers-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/numbers-4/index.html
+++ b/lessons/lesson-2/numbers-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/numbers-5/index.html
+++ b/lessons/lesson-2/numbers-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/vocab-1/index.html
+++ b/lessons/lesson-2/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/vocab-2/index.html
+++ b/lessons/lesson-2/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/vocab-3/index.html
+++ b/lessons/lesson-2/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/vocab-4/index.html
+++ b/lessons/lesson-2/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/vocab-5/index.html
+++ b/lessons/lesson-2/vocab-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/vocab-6/index.html
+++ b/lessons/lesson-2/vocab-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/vocab-7/index.html
+++ b/lessons/lesson-2/vocab-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/vocab-8/index.html
+++ b/lessons/lesson-2/vocab-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/workbook-1/index.html
+++ b/lessons/lesson-2/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/workbook-2/index.html
+++ b/lessons/lesson-2/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/workbook-3/index.html
+++ b/lessons/lesson-2/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/workbook-4/index.html
+++ b/lessons/lesson-2/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/workbook-5/index.html
+++ b/lessons/lesson-2/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/workbook-6/index.html
+++ b/lessons/lesson-2/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/workbook-7/index.html
+++ b/lessons/lesson-2/workbook-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-2/workbook-8/index.html
+++ b/lessons/lesson-2/workbook-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/culture-1/index.html
+++ b/lessons/lesson-20/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/grammar-1/index.html
+++ b/lessons/lesson-20/grammar-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/grammar-10/index.html
+++ b/lessons/lesson-20/grammar-10/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/grammar-2/index.html
+++ b/lessons/lesson-20/grammar-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/grammar-3/index.html
+++ b/lessons/lesson-20/grammar-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/grammar-4/index.html
+++ b/lessons/lesson-20/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/grammar-5/index.html
+++ b/lessons/lesson-20/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/grammar-6/index.html
+++ b/lessons/lesson-20/grammar-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/grammar-7/index.html
+++ b/lessons/lesson-20/grammar-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/grammar-8/index.html
+++ b/lessons/lesson-20/grammar-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/grammar-9/index.html
+++ b/lessons/lesson-20/grammar-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/literacy-1/index.html
+++ b/lessons/lesson-20/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/literacy-2/index.html
+++ b/lessons/lesson-20/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/literacy-3/index.html
+++ b/lessons/lesson-20/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/literacy-4/index.html
+++ b/lessons/lesson-20/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/literacy-5/index.html
+++ b/lessons/lesson-20/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/literacy-6/index.html
+++ b/lessons/lesson-20/literacy-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/literacy-7/index.html
+++ b/lessons/lesson-20/literacy-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/literacy-wb-1/index.html
+++ b/lessons/lesson-20/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/literacy-wb-2/index.html
+++ b/lessons/lesson-20/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/literacy-wb-3/index.html
+++ b/lessons/lesson-20/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/literacy-wb-4/index.html
+++ b/lessons/lesson-20/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/literacy-wb-5/index.html
+++ b/lessons/lesson-20/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/literacy-wb-6/index.html
+++ b/lessons/lesson-20/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/vocab-1/index.html
+++ b/lessons/lesson-20/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/vocab-2/index.html
+++ b/lessons/lesson-20/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/vocab-3/index.html
+++ b/lessons/lesson-20/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/vocab-4/index.html
+++ b/lessons/lesson-20/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/vocab-5/index.html
+++ b/lessons/lesson-20/vocab-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/workbook-1/index.html
+++ b/lessons/lesson-20/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/workbook-2/index.html
+++ b/lessons/lesson-20/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/workbook-3/index.html
+++ b/lessons/lesson-20/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/workbook-4/index.html
+++ b/lessons/lesson-20/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/workbook-5/index.html
+++ b/lessons/lesson-20/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/workbook-6/index.html
+++ b/lessons/lesson-20/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/workbook-7/index.html
+++ b/lessons/lesson-20/workbook-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/workbook-8/index.html
+++ b/lessons/lesson-20/workbook-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-20/workbook-9/index.html
+++ b/lessons/lesson-20/workbook-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/culture-1/index.html
+++ b/lessons/lesson-21/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/culture-2/index.html
+++ b/lessons/lesson-21/culture-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/grammar-1/index.html
+++ b/lessons/lesson-21/grammar-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/grammar-2/index.html
+++ b/lessons/lesson-21/grammar-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/grammar-3/index.html
+++ b/lessons/lesson-21/grammar-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/grammar-4/index.html
+++ b/lessons/lesson-21/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/grammar-5/index.html
+++ b/lessons/lesson-21/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/grammar-6/index.html
+++ b/lessons/lesson-21/grammar-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/literacy-1/index.html
+++ b/lessons/lesson-21/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/literacy-2/index.html
+++ b/lessons/lesson-21/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/literacy-3/index.html
+++ b/lessons/lesson-21/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/literacy-4/index.html
+++ b/lessons/lesson-21/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/literacy-5/index.html
+++ b/lessons/lesson-21/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/literacy-6/index.html
+++ b/lessons/lesson-21/literacy-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/literacy-7/index.html
+++ b/lessons/lesson-21/literacy-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/literacy-wb-1/index.html
+++ b/lessons/lesson-21/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/literacy-wb-2/index.html
+++ b/lessons/lesson-21/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/literacy-wb-3/index.html
+++ b/lessons/lesson-21/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/literacy-wb-4/index.html
+++ b/lessons/lesson-21/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/literacy-wb-5/index.html
+++ b/lessons/lesson-21/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/literacy-wb-6/index.html
+++ b/lessons/lesson-21/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/vocab-1/index.html
+++ b/lessons/lesson-21/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/vocab-2/index.html
+++ b/lessons/lesson-21/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/vocab-3/index.html
+++ b/lessons/lesson-21/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/vocab-4/index.html
+++ b/lessons/lesson-21/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/vocab-5/index.html
+++ b/lessons/lesson-21/vocab-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/workbook-1/index.html
+++ b/lessons/lesson-21/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/workbook-2/index.html
+++ b/lessons/lesson-21/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/workbook-3/index.html
+++ b/lessons/lesson-21/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/workbook-4/index.html
+++ b/lessons/lesson-21/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/workbook-5/index.html
+++ b/lessons/lesson-21/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/workbook-6/index.html
+++ b/lessons/lesson-21/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/workbook-7/index.html
+++ b/lessons/lesson-21/workbook-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/workbook-8/index.html
+++ b/lessons/lesson-21/workbook-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-21/workbook-9/index.html
+++ b/lessons/lesson-21/workbook-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/culture-1/index.html
+++ b/lessons/lesson-22/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/culture-2/index.html
+++ b/lessons/lesson-22/culture-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/grammar-1/index.html
+++ b/lessons/lesson-22/grammar-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/grammar-2/index.html
+++ b/lessons/lesson-22/grammar-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/grammar-3/index.html
+++ b/lessons/lesson-22/grammar-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/grammar-4/index.html
+++ b/lessons/lesson-22/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/grammar-5/index.html
+++ b/lessons/lesson-22/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/grammar-6/index.html
+++ b/lessons/lesson-22/grammar-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/grammar-7/index.html
+++ b/lessons/lesson-22/grammar-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/grammar-8/index.html
+++ b/lessons/lesson-22/grammar-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/literacy-1/index.html
+++ b/lessons/lesson-22/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/literacy-2/index.html
+++ b/lessons/lesson-22/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/literacy-3/index.html
+++ b/lessons/lesson-22/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/literacy-4/index.html
+++ b/lessons/lesson-22/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/literacy-5/index.html
+++ b/lessons/lesson-22/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/literacy-6/index.html
+++ b/lessons/lesson-22/literacy-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/literacy-7/index.html
+++ b/lessons/lesson-22/literacy-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/literacy-wb-1/index.html
+++ b/lessons/lesson-22/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/literacy-wb-2/index.html
+++ b/lessons/lesson-22/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/literacy-wb-3/index.html
+++ b/lessons/lesson-22/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/literacy-wb-4/index.html
+++ b/lessons/lesson-22/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/literacy-wb-5/index.html
+++ b/lessons/lesson-22/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/literacy-wb-6/index.html
+++ b/lessons/lesson-22/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/vocab-1/index.html
+++ b/lessons/lesson-22/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/vocab-2/index.html
+++ b/lessons/lesson-22/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/vocab-3/index.html
+++ b/lessons/lesson-22/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/vocab-4/index.html
+++ b/lessons/lesson-22/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/vocab-5/index.html
+++ b/lessons/lesson-22/vocab-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/workbook-1/index.html
+++ b/lessons/lesson-22/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/workbook-2/index.html
+++ b/lessons/lesson-22/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/workbook-3/index.html
+++ b/lessons/lesson-22/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/workbook-4/index.html
+++ b/lessons/lesson-22/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/workbook-5/index.html
+++ b/lessons/lesson-22/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/workbook-6/index.html
+++ b/lessons/lesson-22/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/workbook-7/index.html
+++ b/lessons/lesson-22/workbook-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/workbook-8/index.html
+++ b/lessons/lesson-22/workbook-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-22/workbook-9/index.html
+++ b/lessons/lesson-22/workbook-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/culture-1/index.html
+++ b/lessons/lesson-23/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/grammar-1/index.html
+++ b/lessons/lesson-23/grammar-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/grammar-2/index.html
+++ b/lessons/lesson-23/grammar-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/grammar-3/index.html
+++ b/lessons/lesson-23/grammar-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/grammar-4/index.html
+++ b/lessons/lesson-23/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/grammar-5/index.html
+++ b/lessons/lesson-23/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/grammar-6/index.html
+++ b/lessons/lesson-23/grammar-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/grammar-7/index.html
+++ b/lessons/lesson-23/grammar-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/grammar-8/index.html
+++ b/lessons/lesson-23/grammar-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/grammar-9/index.html
+++ b/lessons/lesson-23/grammar-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/literacy-1/index.html
+++ b/lessons/lesson-23/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/literacy-2/index.html
+++ b/lessons/lesson-23/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/literacy-3/index.html
+++ b/lessons/lesson-23/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/literacy-4/index.html
+++ b/lessons/lesson-23/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/literacy-5/index.html
+++ b/lessons/lesson-23/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/literacy-6/index.html
+++ b/lessons/lesson-23/literacy-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/literacy-7/index.html
+++ b/lessons/lesson-23/literacy-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/literacy-wb-1/index.html
+++ b/lessons/lesson-23/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/literacy-wb-2/index.html
+++ b/lessons/lesson-23/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/literacy-wb-3/index.html
+++ b/lessons/lesson-23/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/literacy-wb-4/index.html
+++ b/lessons/lesson-23/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/literacy-wb-5/index.html
+++ b/lessons/lesson-23/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/literacy-wb-6/index.html
+++ b/lessons/lesson-23/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/vocab-1/index.html
+++ b/lessons/lesson-23/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/vocab-2/index.html
+++ b/lessons/lesson-23/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/vocab-3/index.html
+++ b/lessons/lesson-23/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/vocab-4/index.html
+++ b/lessons/lesson-23/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/vocab-5/index.html
+++ b/lessons/lesson-23/vocab-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/workbook-1/index.html
+++ b/lessons/lesson-23/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/workbook-10/index.html
+++ b/lessons/lesson-23/workbook-10/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/workbook-2/index.html
+++ b/lessons/lesson-23/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/workbook-3/index.html
+++ b/lessons/lesson-23/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/workbook-4/index.html
+++ b/lessons/lesson-23/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/workbook-5/index.html
+++ b/lessons/lesson-23/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/workbook-6/index.html
+++ b/lessons/lesson-23/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/workbook-7/index.html
+++ b/lessons/lesson-23/workbook-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/workbook-8/index.html
+++ b/lessons/lesson-23/workbook-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-23/workbook-9/index.html
+++ b/lessons/lesson-23/workbook-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/culture-1/index.html
+++ b/lessons/lesson-3/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/grammar-1/index.html
+++ b/lessons/lesson-3/grammar-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/grammar-2/index.html
+++ b/lessons/lesson-3/grammar-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/grammar-3/index.html
+++ b/lessons/lesson-3/grammar-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/grammar-4/index.html
+++ b/lessons/lesson-3/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/grammar-5/index.html
+++ b/lessons/lesson-3/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/grammar-6/index.html
+++ b/lessons/lesson-3/grammar-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/grammar-7/index.html
+++ b/lessons/lesson-3/grammar-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/literacy-1/index.html
+++ b/lessons/lesson-3/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/literacy-2/index.html
+++ b/lessons/lesson-3/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/literacy-3/index.html
+++ b/lessons/lesson-3/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/literacy-4/index.html
+++ b/lessons/lesson-3/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/literacy-5/index.html
+++ b/lessons/lesson-3/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/literacy-6/index.html
+++ b/lessons/lesson-3/literacy-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/literacy-7/index.html
+++ b/lessons/lesson-3/literacy-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/literacy-8/index.html
+++ b/lessons/lesson-3/literacy-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/literacy-9/index.html
+++ b/lessons/lesson-3/literacy-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/literacy-wb-1/index.html
+++ b/lessons/lesson-3/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/literacy-wb-2/index.html
+++ b/lessons/lesson-3/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/literacy-wb-3/index.html
+++ b/lessons/lesson-3/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/literacy-wb-4/index.html
+++ b/lessons/lesson-3/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/literacy-wb-5/index.html
+++ b/lessons/lesson-3/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/literacy-wb-6/index.html
+++ b/lessons/lesson-3/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/literacy-wb-7/index.html
+++ b/lessons/lesson-3/literacy-wb-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/literacy-wb-8/index.html
+++ b/lessons/lesson-3/literacy-wb-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/literacy-wb-9/index.html
+++ b/lessons/lesson-3/literacy-wb-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/vocab-1/index.html
+++ b/lessons/lesson-3/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/vocab-2/index.html
+++ b/lessons/lesson-3/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/vocab-3/index.html
+++ b/lessons/lesson-3/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/vocab-4/index.html
+++ b/lessons/lesson-3/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/vocab-5/index.html
+++ b/lessons/lesson-3/vocab-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/vocab-6/index.html
+++ b/lessons/lesson-3/vocab-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/vocab-7/index.html
+++ b/lessons/lesson-3/vocab-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/workbook-1/index.html
+++ b/lessons/lesson-3/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/workbook-10/index.html
+++ b/lessons/lesson-3/workbook-10/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/workbook-2/index.html
+++ b/lessons/lesson-3/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/workbook-3/index.html
+++ b/lessons/lesson-3/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/workbook-4/index.html
+++ b/lessons/lesson-3/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/workbook-5/index.html
+++ b/lessons/lesson-3/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/workbook-6/index.html
+++ b/lessons/lesson-3/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/workbook-7/index.html
+++ b/lessons/lesson-3/workbook-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/workbook-8/index.html
+++ b/lessons/lesson-3/workbook-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-3/workbook-9/index.html
+++ b/lessons/lesson-3/workbook-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/culture-1/index.html
+++ b/lessons/lesson-4/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/grammar-1/index.html
+++ b/lessons/lesson-4/grammar-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/grammar-2/index.html
+++ b/lessons/lesson-4/grammar-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/grammar-3/index.html
+++ b/lessons/lesson-4/grammar-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/grammar-4/index.html
+++ b/lessons/lesson-4/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/grammar-5/index.html
+++ b/lessons/lesson-4/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/grammar-6/index.html
+++ b/lessons/lesson-4/grammar-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/grammar-7/index.html
+++ b/lessons/lesson-4/grammar-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/grammar-8/index.html
+++ b/lessons/lesson-4/grammar-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/grammar-9/index.html
+++ b/lessons/lesson-4/grammar-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/literacy-1/index.html
+++ b/lessons/lesson-4/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/literacy-10/index.html
+++ b/lessons/lesson-4/literacy-10/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/literacy-2/index.html
+++ b/lessons/lesson-4/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/literacy-3/index.html
+++ b/lessons/lesson-4/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/literacy-4/index.html
+++ b/lessons/lesson-4/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/literacy-5/index.html
+++ b/lessons/lesson-4/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/literacy-6/index.html
+++ b/lessons/lesson-4/literacy-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/literacy-7/index.html
+++ b/lessons/lesson-4/literacy-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/literacy-8/index.html
+++ b/lessons/lesson-4/literacy-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/literacy-9/index.html
+++ b/lessons/lesson-4/literacy-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/literacy-wb-1/index.html
+++ b/lessons/lesson-4/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/literacy-wb-2/index.html
+++ b/lessons/lesson-4/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/literacy-wb-3/index.html
+++ b/lessons/lesson-4/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/literacy-wb-4/index.html
+++ b/lessons/lesson-4/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/literacy-wb-5/index.html
+++ b/lessons/lesson-4/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/literacy-wb-6/index.html
+++ b/lessons/lesson-4/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/literacy-wb-7/index.html
+++ b/lessons/lesson-4/literacy-wb-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/literacy-wb-8/index.html
+++ b/lessons/lesson-4/literacy-wb-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/vocab-1/index.html
+++ b/lessons/lesson-4/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/vocab-10/index.html
+++ b/lessons/lesson-4/vocab-10/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/vocab-2/index.html
+++ b/lessons/lesson-4/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/vocab-3/index.html
+++ b/lessons/lesson-4/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/vocab-4/index.html
+++ b/lessons/lesson-4/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/vocab-5/index.html
+++ b/lessons/lesson-4/vocab-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/vocab-6/index.html
+++ b/lessons/lesson-4/vocab-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/vocab-7/index.html
+++ b/lessons/lesson-4/vocab-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/vocab-8/index.html
+++ b/lessons/lesson-4/vocab-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/vocab-9/index.html
+++ b/lessons/lesson-4/vocab-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/workbook-1/index.html
+++ b/lessons/lesson-4/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/workbook-2/index.html
+++ b/lessons/lesson-4/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/workbook-3/index.html
+++ b/lessons/lesson-4/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/workbook-4/index.html
+++ b/lessons/lesson-4/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/workbook-5/index.html
+++ b/lessons/lesson-4/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/workbook-6/index.html
+++ b/lessons/lesson-4/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/workbook-7/index.html
+++ b/lessons/lesson-4/workbook-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/workbook-8/index.html
+++ b/lessons/lesson-4/workbook-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-4/workbook-9/index.html
+++ b/lessons/lesson-4/workbook-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/culture-1/index.html
+++ b/lessons/lesson-5/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/grammar-1/index.html
+++ b/lessons/lesson-5/grammar-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/grammar-10/index.html
+++ b/lessons/lesson-5/grammar-10/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/grammar-11/index.html
+++ b/lessons/lesson-5/grammar-11/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/grammar-12/index.html
+++ b/lessons/lesson-5/grammar-12/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/grammar-13/index.html
+++ b/lessons/lesson-5/grammar-13/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/grammar-2/index.html
+++ b/lessons/lesson-5/grammar-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/grammar-3/index.html
+++ b/lessons/lesson-5/grammar-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/grammar-4/index.html
+++ b/lessons/lesson-5/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/grammar-5/index.html
+++ b/lessons/lesson-5/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/grammar-6/index.html
+++ b/lessons/lesson-5/grammar-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/grammar-7/index.html
+++ b/lessons/lesson-5/grammar-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/grammar-8/index.html
+++ b/lessons/lesson-5/grammar-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/grammar-9/index.html
+++ b/lessons/lesson-5/grammar-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/literacy-1/index.html
+++ b/lessons/lesson-5/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/literacy-10/index.html
+++ b/lessons/lesson-5/literacy-10/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/literacy-11/index.html
+++ b/lessons/lesson-5/literacy-11/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/literacy-2/index.html
+++ b/lessons/lesson-5/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/literacy-3/index.html
+++ b/lessons/lesson-5/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/literacy-4/index.html
+++ b/lessons/lesson-5/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/literacy-5/index.html
+++ b/lessons/lesson-5/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/literacy-6/index.html
+++ b/lessons/lesson-5/literacy-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/literacy-7/index.html
+++ b/lessons/lesson-5/literacy-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/literacy-8/index.html
+++ b/lessons/lesson-5/literacy-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/literacy-9/index.html
+++ b/lessons/lesson-5/literacy-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/literacy-wb-1/index.html
+++ b/lessons/lesson-5/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/literacy-wb-2/index.html
+++ b/lessons/lesson-5/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/literacy-wb-3/index.html
+++ b/lessons/lesson-5/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/literacy-wb-4/index.html
+++ b/lessons/lesson-5/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/literacy-wb-5/index.html
+++ b/lessons/lesson-5/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/literacy-wb-6/index.html
+++ b/lessons/lesson-5/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/literacy-wb-7/index.html
+++ b/lessons/lesson-5/literacy-wb-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/vocab-1/index.html
+++ b/lessons/lesson-5/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/vocab-2/index.html
+++ b/lessons/lesson-5/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/vocab-3/index.html
+++ b/lessons/lesson-5/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/vocab-4/index.html
+++ b/lessons/lesson-5/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/vocab-5/index.html
+++ b/lessons/lesson-5/vocab-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/vocab-6/index.html
+++ b/lessons/lesson-5/vocab-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/workbook-1/index.html
+++ b/lessons/lesson-5/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/workbook-2/index.html
+++ b/lessons/lesson-5/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/workbook-3/index.html
+++ b/lessons/lesson-5/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/workbook-4/index.html
+++ b/lessons/lesson-5/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/workbook-5/index.html
+++ b/lessons/lesson-5/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/workbook-6/index.html
+++ b/lessons/lesson-5/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/workbook-7/index.html
+++ b/lessons/lesson-5/workbook-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/workbook-8/index.html
+++ b/lessons/lesson-5/workbook-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-5/workbook-9/index.html
+++ b/lessons/lesson-5/workbook-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/culture-1/index.html
+++ b/lessons/lesson-6/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/grammar-1/index.html
+++ b/lessons/lesson-6/grammar-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/grammar-2/index.html
+++ b/lessons/lesson-6/grammar-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/grammar-3/index.html
+++ b/lessons/lesson-6/grammar-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/grammar-4/index.html
+++ b/lessons/lesson-6/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/grammar-5/index.html
+++ b/lessons/lesson-6/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/grammar-6/index.html
+++ b/lessons/lesson-6/grammar-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/grammar-7/index.html
+++ b/lessons/lesson-6/grammar-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/grammar-8/index.html
+++ b/lessons/lesson-6/grammar-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/grammar-9/index.html
+++ b/lessons/lesson-6/grammar-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/literacy-1/index.html
+++ b/lessons/lesson-6/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/literacy-10/index.html
+++ b/lessons/lesson-6/literacy-10/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/literacy-11/index.html
+++ b/lessons/lesson-6/literacy-11/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/literacy-2/index.html
+++ b/lessons/lesson-6/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/literacy-3/index.html
+++ b/lessons/lesson-6/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/literacy-4/index.html
+++ b/lessons/lesson-6/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/literacy-5/index.html
+++ b/lessons/lesson-6/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/literacy-6/index.html
+++ b/lessons/lesson-6/literacy-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/literacy-7/index.html
+++ b/lessons/lesson-6/literacy-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/literacy-8/index.html
+++ b/lessons/lesson-6/literacy-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/literacy-9/index.html
+++ b/lessons/lesson-6/literacy-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/literacy-wb-1/index.html
+++ b/lessons/lesson-6/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/literacy-wb-2/index.html
+++ b/lessons/lesson-6/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/literacy-wb-3/index.html
+++ b/lessons/lesson-6/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/literacy-wb-4/index.html
+++ b/lessons/lesson-6/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/literacy-wb-5/index.html
+++ b/lessons/lesson-6/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/literacy-wb-6/index.html
+++ b/lessons/lesson-6/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/literacy-wb-7/index.html
+++ b/lessons/lesson-6/literacy-wb-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/literacy-wb-8/index.html
+++ b/lessons/lesson-6/literacy-wb-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/vocab-1/index.html
+++ b/lessons/lesson-6/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/vocab-2/index.html
+++ b/lessons/lesson-6/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/vocab-3/index.html
+++ b/lessons/lesson-6/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/vocab-4/index.html
+++ b/lessons/lesson-6/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/vocab-5/index.html
+++ b/lessons/lesson-6/vocab-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/workbook-1/index.html
+++ b/lessons/lesson-6/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/workbook-2/index.html
+++ b/lessons/lesson-6/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/workbook-3/index.html
+++ b/lessons/lesson-6/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/workbook-4/index.html
+++ b/lessons/lesson-6/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/workbook-5/index.html
+++ b/lessons/lesson-6/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/workbook-6/index.html
+++ b/lessons/lesson-6/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/workbook-7/index.html
+++ b/lessons/lesson-6/workbook-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/workbook-8/index.html
+++ b/lessons/lesson-6/workbook-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-6/workbook-9/index.html
+++ b/lessons/lesson-6/workbook-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/culture-1/index.html
+++ b/lessons/lesson-7/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/culture-2/index.html
+++ b/lessons/lesson-7/culture-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/grammar-1/index.html
+++ b/lessons/lesson-7/grammar-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/grammar-2/index.html
+++ b/lessons/lesson-7/grammar-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/grammar-3/index.html
+++ b/lessons/lesson-7/grammar-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/grammar-4/index.html
+++ b/lessons/lesson-7/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/grammar-5/index.html
+++ b/lessons/lesson-7/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/grammar-6/index.html
+++ b/lessons/lesson-7/grammar-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/grammar-7/index.html
+++ b/lessons/lesson-7/grammar-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/literacy-1/index.html
+++ b/lessons/lesson-7/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/literacy-2/index.html
+++ b/lessons/lesson-7/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/literacy-3/index.html
+++ b/lessons/lesson-7/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/literacy-4/index.html
+++ b/lessons/lesson-7/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/literacy-5/index.html
+++ b/lessons/lesson-7/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/literacy-6/index.html
+++ b/lessons/lesson-7/literacy-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/literacy-7/index.html
+++ b/lessons/lesson-7/literacy-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/literacy-8/index.html
+++ b/lessons/lesson-7/literacy-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/literacy-wb-1/index.html
+++ b/lessons/lesson-7/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/literacy-wb-2/index.html
+++ b/lessons/lesson-7/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/literacy-wb-3/index.html
+++ b/lessons/lesson-7/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/literacy-wb-4/index.html
+++ b/lessons/lesson-7/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/literacy-wb-5/index.html
+++ b/lessons/lesson-7/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/literacy-wb-6/index.html
+++ b/lessons/lesson-7/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/literacy-wb-7/index.html
+++ b/lessons/lesson-7/literacy-wb-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/vocab-1/index.html
+++ b/lessons/lesson-7/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/vocab-2/index.html
+++ b/lessons/lesson-7/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/vocab-3/index.html
+++ b/lessons/lesson-7/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/vocab-4/index.html
+++ b/lessons/lesson-7/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/vocab-5/index.html
+++ b/lessons/lesson-7/vocab-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/vocab-6/index.html
+++ b/lessons/lesson-7/vocab-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/vocab-7/index.html
+++ b/lessons/lesson-7/vocab-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/workbook-1/index.html
+++ b/lessons/lesson-7/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/workbook-2/index.html
+++ b/lessons/lesson-7/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/workbook-3/index.html
+++ b/lessons/lesson-7/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/workbook-4/index.html
+++ b/lessons/lesson-7/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/workbook-5/index.html
+++ b/lessons/lesson-7/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/workbook-6/index.html
+++ b/lessons/lesson-7/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/workbook-7/index.html
+++ b/lessons/lesson-7/workbook-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/workbook-8/index.html
+++ b/lessons/lesson-7/workbook-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-7/workbook-9/index.html
+++ b/lessons/lesson-7/workbook-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/culture-1/index.html
+++ b/lessons/lesson-8/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/grammar-1/index.html
+++ b/lessons/lesson-8/grammar-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/grammar-10/index.html
+++ b/lessons/lesson-8/grammar-10/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/grammar-11/index.html
+++ b/lessons/lesson-8/grammar-11/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/grammar-12/index.html
+++ b/lessons/lesson-8/grammar-12/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/grammar-2/index.html
+++ b/lessons/lesson-8/grammar-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/grammar-3/index.html
+++ b/lessons/lesson-8/grammar-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/grammar-4/index.html
+++ b/lessons/lesson-8/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/grammar-5/index.html
+++ b/lessons/lesson-8/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/grammar-6/index.html
+++ b/lessons/lesson-8/grammar-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/grammar-7/index.html
+++ b/lessons/lesson-8/grammar-7/index.html
@@ -54,7 +54,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/grammar-8/index.html
+++ b/lessons/lesson-8/grammar-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/grammar-9/index.html
+++ b/lessons/lesson-8/grammar-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/literacy-1/index.html
+++ b/lessons/lesson-8/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/literacy-2/index.html
+++ b/lessons/lesson-8/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/literacy-3/index.html
+++ b/lessons/lesson-8/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/literacy-4/index.html
+++ b/lessons/lesson-8/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/literacy-5/index.html
+++ b/lessons/lesson-8/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/literacy-6/index.html
+++ b/lessons/lesson-8/literacy-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/literacy-7/index.html
+++ b/lessons/lesson-8/literacy-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/literacy-wb-1/index.html
+++ b/lessons/lesson-8/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/literacy-wb-2/index.html
+++ b/lessons/lesson-8/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/literacy-wb-3/index.html
+++ b/lessons/lesson-8/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/literacy-wb-4/index.html
+++ b/lessons/lesson-8/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/literacy-wb-5/index.html
+++ b/lessons/lesson-8/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/literacy-wb-6/index.html
+++ b/lessons/lesson-8/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/literacy-wb-7/index.html
+++ b/lessons/lesson-8/literacy-wb-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/vocab-1/index.html
+++ b/lessons/lesson-8/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/vocab-2/index.html
+++ b/lessons/lesson-8/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/vocab-3/index.html
+++ b/lessons/lesson-8/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/vocab-4/index.html
+++ b/lessons/lesson-8/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/vocab-5/index.html
+++ b/lessons/lesson-8/vocab-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/vocab-6/index.html
+++ b/lessons/lesson-8/vocab-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/workbook-1/index.html
+++ b/lessons/lesson-8/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/workbook-2/index.html
+++ b/lessons/lesson-8/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/workbook-3/index.html
+++ b/lessons/lesson-8/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/workbook-4/index.html
+++ b/lessons/lesson-8/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/workbook-5/index.html
+++ b/lessons/lesson-8/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/workbook-6/index.html
+++ b/lessons/lesson-8/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/workbook-7/index.html
+++ b/lessons/lesson-8/workbook-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/workbook-8/index.html
+++ b/lessons/lesson-8/workbook-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-8/workbook-9/index.html
+++ b/lessons/lesson-8/workbook-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/culture-1/index.html
+++ b/lessons/lesson-9/culture-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/grammar-1/index.html
+++ b/lessons/lesson-9/grammar-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/grammar-10/index.html
+++ b/lessons/lesson-9/grammar-10/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/grammar-2/index.html
+++ b/lessons/lesson-9/grammar-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/grammar-3/index.html
+++ b/lessons/lesson-9/grammar-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/grammar-4/index.html
+++ b/lessons/lesson-9/grammar-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/grammar-5/index.html
+++ b/lessons/lesson-9/grammar-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/grammar-6/index.html
+++ b/lessons/lesson-9/grammar-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/grammar-7/index.html
+++ b/lessons/lesson-9/grammar-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/grammar-8/index.html
+++ b/lessons/lesson-9/grammar-8/index.html
@@ -54,7 +54,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/grammar-9/index.html
+++ b/lessons/lesson-9/grammar-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/literacy-1/index.html
+++ b/lessons/lesson-9/literacy-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/literacy-2/index.html
+++ b/lessons/lesson-9/literacy-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/literacy-3/index.html
+++ b/lessons/lesson-9/literacy-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/literacy-4/index.html
+++ b/lessons/lesson-9/literacy-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/literacy-5/index.html
+++ b/lessons/lesson-9/literacy-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/literacy-6/index.html
+++ b/lessons/lesson-9/literacy-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/literacy-7/index.html
+++ b/lessons/lesson-9/literacy-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/literacy-8/index.html
+++ b/lessons/lesson-9/literacy-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/literacy-9/index.html
+++ b/lessons/lesson-9/literacy-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/literacy-wb-1/index.html
+++ b/lessons/lesson-9/literacy-wb-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/literacy-wb-2/index.html
+++ b/lessons/lesson-9/literacy-wb-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/literacy-wb-3/index.html
+++ b/lessons/lesson-9/literacy-wb-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/literacy-wb-4/index.html
+++ b/lessons/lesson-9/literacy-wb-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/literacy-wb-5/index.html
+++ b/lessons/lesson-9/literacy-wb-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/literacy-wb-6/index.html
+++ b/lessons/lesson-9/literacy-wb-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/literacy-wb-7/index.html
+++ b/lessons/lesson-9/literacy-wb-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/vocab-1/index.html
+++ b/lessons/lesson-9/vocab-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/vocab-2/index.html
+++ b/lessons/lesson-9/vocab-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/vocab-3/index.html
+++ b/lessons/lesson-9/vocab-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/vocab-4/index.html
+++ b/lessons/lesson-9/vocab-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/vocab-5/index.html
+++ b/lessons/lesson-9/vocab-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/vocab-6/index.html
+++ b/lessons/lesson-9/vocab-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/vocab-7/index.html
+++ b/lessons/lesson-9/vocab-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/workbook-1/index.html
+++ b/lessons/lesson-9/workbook-1/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/workbook-2/index.html
+++ b/lessons/lesson-9/workbook-2/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/workbook-3/index.html
+++ b/lessons/lesson-9/workbook-3/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/workbook-4/index.html
+++ b/lessons/lesson-9/workbook-4/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/workbook-5/index.html
+++ b/lessons/lesson-9/workbook-5/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/workbook-6/index.html
+++ b/lessons/lesson-9/workbook-6/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/workbook-7/index.html
+++ b/lessons/lesson-9/workbook-7/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/workbook-8/index.html
+++ b/lessons/lesson-9/workbook-8/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/lesson-9/workbook-9/index.html
+++ b/lessons/lesson-9/workbook-9/index.html
@@ -50,7 +50,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/study-tools/custom-quiz/index.html
+++ b/lessons/study-tools/custom-quiz/index.html
@@ -104,7 +104,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/study-tools/custom-spelling/index.html
+++ b/lessons/study-tools/custom-spelling/index.html
@@ -98,7 +98,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/study-tools/custom-vocab/index.html
+++ b/lessons/study-tools/custom-vocab/index.html
@@ -98,7 +98,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/lessons/study-tools/custom-written-quiz/index.html
+++ b/lessons/study-tools/custom-written-quiz/index.html
@@ -497,7 +497,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -93,7 +93,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     

--- a/report/index.html
+++ b/report/index.html
@@ -38,7 +38,7 @@
         <h2 class="title center" id="genki-reporting-help">Report a Bug</h2>
         <p>Have you found a bug or mistake on Genki Study Resources or just want to submit general feedback? If so, you can let us know by opening a new issue! Please read the information provided below to learn how to submit your report or feedback.</p>
         
-        <p><strong>Note:</strong> We utilize Github's "Issues" tracker to collect user feedback. If you're not familiar with this system you can read about it <a href="https://help.github.com/articles/about-issues/">here</a>. A Github account is required to submit new issues. If you don't have one you can register an account <a href="https://github.com/join">here</a> (optional, see below for alternatives).</p>
+        <p><strong>Note:</strong> We utilize GitHub's "Issues" tracker to collect user feedback. If you're not familiar with this system you can read about it <a href="https://help.github.com/articles/about-issues/">here</a>. A GitHub account is required to submit new issues. If you don't have one you can register an account <a href="https://github.com/join">here</a> (optional, see below for alternatives).</p>
         
         <h3 class="sub-title" id="genki-report-quick-nav">Quick Navigation</h3>
         <ul>
@@ -96,7 +96,7 @@
         <h2 class="section-title" id="report-other">General Feedback</h2>
         <p>Does your query not meet the conditions listed above? No problem, we'd still love to hear from you! If you have a suggestion, complaint, or comment, feel free to open a new issue on github or leave a comment in the following topic on reddit to let us know.</p>
         <ul>
-          <li><a href="https://github.com/SethClydesdale/genki-study-resources/issues">Github</a></li>
+          <li><a href="https://github.com/SethClydesdale/genki-study-resources/issues">GitHub</a></li>
           <li><a href="https://www.reddit.com/r/LearnJapanese/comments/e725cx/g/">Reddit</a></li>
         </ul>
         <p>Any and all feedback is appreciated; we look forward to hearing from you!</p>
@@ -112,7 +112,7 @@
       </ul>
       
       <ul class="footer-right">
-        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">Github Community</a></li>
+        <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
     


### PR DESCRIPTION
Just a quick PR fixing the GitHub spelling (`Github` -> `GitHub`).

Awesome project! :+1: