### PR TITLE
add missing `さい` to answer to make it same as kanji answer

### DIFF
--- a/lessons/lesson-2/workbook-5/index.html
+++ b/lessons/lesson-2/workbook-5/index.html
@@ -74,8 +74,8 @@
         
         '<div class="problem">'+
           'Ms. Tanaka is 20 years old. <span class="ul">Mr. Yoshida</span> is 20 years old, too.<br>'+
-          '{たなかさんははたちです|たなかさんは二十歳です|answer}。'+
-          '{よしださんもはたちです|よしださんも二十歳です|answer}。'+
+          '{たなかさんははたちさいです|たなかさんは二十歳です|answer}。'+
+          '{よしださんもはたちさいです|よしださんも二十歳です|answer}。'+
         '</div>'+
         
         '<div class="problem">'+


### PR DESCRIPTION
I finally started to not only watch this repo, but actually use what you've been building! Thanks a bunch!

Just got confused when my answer for this workbook lesson was marked as wrong, because I included the "さい", yet did not auto complete my hiragana to kanji.

I don't know enough about Japanese yet to tell whether in colloquial speech it's fine to leave it out, but the kanji and hiragana answers should surely be the same, I suppose. :)