### PR TITLE
Fix missing index on lessons-3d lesson-6 grammar-3

### DIFF
--- a/lessons-3rd/lesson-6/grammar-3/index.html
+++ b/lessons-3rd/lesson-6/grammar-3/index.html
@@ -177,7 +177,10 @@
             
             '<div class="problem">'+
               'The boyfriend wants his girlfriend to hurry up.<br>'+
-              '{急いでください|いそいでください|answer}。<br><br><br>'+
+              '{急いでください|いそいでください|answer}。'+
+            '</div>'+
+        
+            '<div class="problem">'+
               'The girlfriend wants her boyfriend to wait.<br>'+
               '{待ってください|まってください|answer}。'+
             '</div>'+


### PR DESCRIPTION
One of the `problems` was nested in another one, causing the index to not show for one of the problems.
Have not tested it locally.