### PR TITLE
Fix typo in lesson 9 grammar 2

### DIFF
--- a/lessons-3rd/lesson-9/grammar-2/index.html
+++ b/lessons-3rd/lesson-9/grammar-2/index.html
@@ -407,7 +407,7 @@
             '<div class="example-problem">'+
               '<div class="inner-problem">'+
                 'たかい　　<i class="fa">&#xf061;</i>　たかくなかった<br><br>'+
-                'がんきな　<i class="fa">&#xf061;</i>　げんきじゃなかった<br><br>'+
+                'げんきな　<i class="fa">&#xf061;</i>　げんきじゃなかった<br><br>'+
                 'がくせい　<i class="fa">&#xf061;</i>　がくせいじゃなかった'+
               '</div>'+
             '</div>'+


### PR DESCRIPTION
Fix for a typo in lesson 9, grammar 2 exercise: げんき was spelled as がんき