### PR TITLE
Fix typos in 3rd Ed., L6 Workbook 9-B

### DIFF
--- a/lessons-3rd/lesson-6/workbook-9/index.html
+++ b/lessons-3rd/lesson-6/workbook-9/index.html
@@ -84,14 +84,14 @@
         'Robert asked:<br><br>'+
         '<div class="count-problems columns-2 clear">'+
           '<div>'+
-            '<div class="problem">{!PLAY|W06-B|5} ({||width:21}) close the window curtain</div>'+
-            '<div class="problem">{!PLAY|W06-B|8} ({||width:21}) turn on the room light</div>'+
+            '<div class="problem">{!PLAY|W06-B|5} ({X}) close the window curtain</div>'+
+            '<div class="problem">{!PLAY|W06-B|8} ({X}) turn on the room light</div>'+
             '<div class="problem">{!PLAY|W06-B|15.5} ({O}) turn on the TV</div>'+
           '</div>'+
         
           '<div>'+
             '<div class="problem">{!PLAY|W06-B|21.5} ({O}) buy a concert ticket</div>'+
-            '<div class="problem">{!PLAY|W06-B|31} ({||width:21}) tell the time in Japan</div>'+
+            '<div class="problem">{!PLAY|W06-B|31} ({X}) tell the time in Japan</div>'+
             '<div class="problem">{!PLAY|W06-B|39} ({O}) call his mother</div>'+
           '</div>'+
         '</div>'+


### PR DESCRIPTION
The original website had `({||width:21})` and not `({X})` in it, and so X would be marked wrong. This PR fixes this issue.

![image](https://user-images.githubusercontent.com/29907828/105914872-f44cc000-5ffc-11eb-89ed-8b7ad5ad1412.png)
