### PR TITLE
Fix duplicate multiple choice question

### DIFF
--- a/lessons-3rd/lesson-12/grammar-2/index.html
+++ b/lessons-3rd/lesson-12/grammar-2/index.html
@@ -105,7 +105,7 @@
             answers : [
               'A<ruby>作<rt>つく</rt></ruby>ったんです。',
               '<ruby>作<rt>つく</rt></ruby>るんです。',
-              '<ruby>作<rt>つく</rt></ruby>ったんです。',
+              '<ruby>作<rt>つく</rt></ruby>たんです。',
               '<ruby>作<rt>つく</rt></ruby>ったです。'
             ]
           },


### PR DESCRIPTION
In Genki 3rd, Lesson 12, Grammar 2, Q4 of the multiple choice question has a duplicate [correct answer](https://imgur.com/a/Ihk7tZN). 

Potential solution:
I removed an extra っ on the incorrect duplicate answer to disambiguate it with the correct answer.

**Note**:
I'm not sure why editing in Github causes a newline to be added to the EOF but I'm happy to remove that if the page fails to compile.

