### PR TITLE
fix typo, add missing furigana

### DIFF
--- a/lessons-3rd/lesson-13/literacy-12/index.html
+++ b/lessons-3rd/lesson-13/literacy-12/index.html
@@ -80,7 +80,7 @@
         
       '<p class="sub-section text-passage vertical-text">'+
         '<br><br><br><br><strong class="t-green">ワティ</strong>　私はコンビニにびっくりしました。日本のコンビニにはいろいろなデザートがあります。時々、昼にコンビニでお<ruby>弁当<rt>べんとう</rt></ruby>とデザートを買います。コンビニのプリンを食べたことがありますか。<ruby>世界<rt>せかい</rt></ruby>で<ruby>一番<rt>いちばん</rt></ruby>おいしいと思います。<br><br>'+
-        '<br><br><br><strong class="t-green">オリバー</strong>　コンビニは<ruby>便利<rt>べんり</rt></ruby>ですね。友だちと海に遊びに行ったんですが、友だちが水着を<ruby>忘<rt>わす</rt></ruby>れたんです。でも近くのコンビニで水着が買えました。コンビニは<ruby>本当<rt>ほんとう</rt></ruby>に“convenient”だと思いました。'+
+        '<br><br><br><strong class="t-green">オリバー</strong>　コンビニは<ruby>便利<rt>べんり</rt></ruby>ですね。友だちと海に<ruby>遊<rt>あそ</rt></ruby>びに行ったんですが、友だちが水着を<ruby>忘<rt>わす</rt></ruby>れたんです。でも近くのコンビニで水着が買えました。コンビニは<ruby>本当<rt>ほんとう</rt></ruby>に“convenient”だと思いました。'+
       '</p>'+
         
       // vocab key

--- a/lessons-3rd/lesson-13/workbook-2/index.html
+++ b/lessons-3rd/lesson-13/workbook-2/index.html
@@ -71,7 +71,7 @@
           '<div class="inner-problem">'+
             '<strong>Things you can do:</strong><br><br>'+
             
-            '(a) {日本語が話せます|にほんごがはなせます|' + Genki.getAlts('{日本語}が{話}せます', 'にほんご|はな') + 'answer;hint:can speak japanese;width:300}。<br><br><br>'+
+            '(a) {日本語が話せます|にほんごがはなせます|' + Genki.getAlts('{日本語}が{話}せます', 'にほんご|はな') + 'answer;hint:can speak Japanese;width:300}。<br><br><br>'+
 
             '(b) {すしが作れます|すしがつくれます|' + Genki.getAlts('{すし}が{作}れます', '寿司|つく') + 'answer;hint:can make sushi;width:300}。'+
           '</div>'+

--- a/lessons/lesson-13/workbook-2/index.html
+++ b/lessons/lesson-13/workbook-2/index.html
@@ -68,7 +68,7 @@
       '<div class="count-problems">'+
         '<p class="section-desc">Things you can do:</p>'+
         '<div class="problem">'+
-          'can speak japanese<br>'+
+          'can speak Japanese<br>'+
           '{日本語が話せます|にほんごがはなせます|' + Genki.getAlts('{日本語}が{話}せます', 'にほんご|はな') + 'answer}。'+
         '</div>'+
         


### PR DESCRIPTION
Hi @SethClydesdale,

First of all, I am very grateful that you are creating exercises for Genki II as well. Thank you!

I have spotted a small typo in one of the exercises for lesson 13 as well as a case of missing furigana in one of the reading practice texts. This pull request should fix those minor issues.

- fixed typo in lesson-13/workbook-2 (2nd ed.)
- fixed typo in lesson-13/workbook-2 (3rd ed.)
- added missing furigana in lesson-13/literacy-12 (3rd ed.)