### PR TITLE
Fixed typo in Lesson 4 Vocab 8

### DIFF
--- a/lessons-3rd/lesson-4/vocab-8/index.html
+++ b/lessons-3rd/lesson-4/vocab-8/index.html
@@ -81,7 +81,7 @@
         'にじゅうはちにち' : 'twenty-eighth day of the month',
         'にじゅうくにち' : 'twenty-ninth day of the month',
         'さんじゅうにち' : 'thirtieth day of the month',
-        'さんじゅういちにち' : 'thiry-first day of the month'
+        'さんじゅういちにち' : 'thirty-first day of the month'
       }
     });</script>
   </body>

--- a/lessons/lesson-4/vocab-8/index.html
+++ b/lessons/lesson-4/vocab-8/index.html
@@ -80,7 +80,7 @@
         'にじゅうはちにち' : 'twenty-eighth day of the month',
         'にじゅうくにち' : 'twenty-ninth day of the month',
         'さんじゅうにち' : 'thirtieth day of the month',
-        'さんじゅういちにち' : 'thiry-first day of the month'
+        'さんじゅういちにち' : 'thirty-first day of the month'
       }
     });</script>
   </body>


### PR DESCRIPTION
Hi, while practicing my Japanese on your site I stumbled upon a small typo.

Changed `'さんじゅういちにち' : 'thiry-first day of the month'` to `'さんじゅういちにち' : 'thirty-first day of the month'` in Lesson 4 Vocab 8 for 2nd and 3rd edition.