### PR TITLE
Fix "yusui" to "yasui" in 3rd edition chapter 10 grammar 1

### DIFF
--- a/lessons-3rd/lesson-10/grammar-1/index.html
+++ b/lessons-3rd/lesson-10/grammar-1/index.html
@@ -103,11 +103,11 @@
           },
 
           {
-            question : '<ruby>新幹線<rt>しんかんせん</rt></ruby>とバスとどちらのほうが<ruby>安<rt>ゆす</rt></ruby>いですか。(see Picture A)',
+            question : '<ruby>新幹線<rt>しんかんせん</rt></ruby>とバスとどちらのほうが<ruby>安<rt>やす</rt></ruby>いですか。(see Picture A)',
             answers : [
-              'Aバスのほうが<ruby>新幹線<rt>しんかんせん</rt></ruby>より<ruby>安<rt>ゆす</rt></ruby>いです。',
+              'Aバスのほうが<ruby>新幹線<rt>しんかんせん</rt></ruby>より<ruby>安<rt>やす</rt></ruby>いです。',
               'バスのほうが<ruby>新幹線<rt>しんかんせん</rt></ruby>より<ruby>高<rt>たか</rt></ruby>いです。',
-              '<ruby>新幹線<rt>しんかんせん</rt></ruby>のほうがバスより<ruby>安<rt>ゆす</rt></ruby>いです。',
+              '<ruby>新幹線<rt>しんかんせん</rt></ruby>のほうがバスより<ruby>安<rt>やす</rt></ruby>いです。',
               '<ruby>新幹線<rt>しんかんせん</rt></ruby>のほうがバスより<ruby>高<rt>たか</rt></ruby>いです。'
             ]
           },
@@ -116,9 +116,9 @@
             question : '<ruby>電車<rt>でんしゃ</rt></ruby>とバスとどちらのほうが<ruby>高<rt>たか</rt></ruby>いですか。(see Picture A)',
             answers : [
               'A<ruby>電車<rt>でんしゃ</rt></ruby>のほうがバスより<ruby>高<rt>たか</rt></ruby>いです。',
-              '<ruby>電車<rt>でんしゃ</rt></ruby>のほうがバスより<ruby>安<rt>ゆす</rt></ruby>いです。',
+              '<ruby>電車<rt>でんしゃ</rt></ruby>のほうがバスより<ruby>安<rt>やす</rt></ruby>いです。',
               'バスのほうが<ruby>電車<rt>でんしゃ</rt></ruby>より<ruby>高<rt>たか</rt></ruby>いです。',
-              'バスのほうが<ruby>電車<rt>でんしゃ</rt></ruby>より<ruby>安<rt>ゆす</rt></ruby>いです。'
+              'バスのほうが<ruby>電車<rt>でんしゃ</rt></ruby>より<ruby>安<rt>やす</rt></ruby>いです。'
             ]
           },
 
@@ -217,8 +217,8 @@
           '</div>'+
           
           '<div class="problem">'+
-            '<ruby>新幹線<rt>しんかんせん</rt></ruby>とバスとどちらのほうが<ruby>安<rt>ゆす</rt></ruby>いですか。<br>'+
-            '{バスのほうが新幹線より安いです|バスのほうがしんかんせんよりゆすいです|' + Genki.getAlts('バスのほうが{新幹線}より{安}いです', 'しんかんせん|やす') + 'answer}。'+
+            '<ruby>新幹線<rt>しんかんせん</rt></ruby>とバスとどちらのほうが<ruby>安<rt>やす</rt></ruby>いですか。<br>'+
+            '{バスのほうが新幹線より安いです|バスのほうがしんかんせんよりやすいです|' + Genki.getAlts('バスのほうが{新幹線}より{安}いです', 'しんかんせん|やす') + 'answer}。'+
           '</div>'+
           
           '<div class="problem">'+


### PR DESCRIPTION
I believe I found errors in the 3rd edition, chapter 10, grammar point 1 for both exercise type "Written" and "Multiple Choice". 

Several questions show that 安い is written as ゆすい. According to the book and jisho.org, it is written やすい.

This pull requests addresses this issue.