### PR TITLE
[typofix] "twelth" -> "twelfth"

### DIFF
--- a/lessons-3rd/lesson-4/vocab-7/index.html
+++ b/lessons-3rd/lesson-4/vocab-7/index.html
@@ -77,7 +77,7 @@
         'ここのか' : 'ninth day of the month',
         'とおか' : 'tenth day of the month',
         'じゅういちにち' : 'eleventh day of the month',
-        'じゅうににち' : 'twelth day of the month',
+        'じゅうににち' : 'twelfth day of the month',
         'じゅうさんにち' : 'thirteenth day of the month',
         'じゅうよっか' : 'fourteenth day of the month',
         'じゅうごにち' : 'fifteenth day of the month'

--- a/lessons/lesson-4/vocab-7/index.html
+++ b/lessons/lesson-4/vocab-7/index.html
@@ -76,7 +76,7 @@
         'ここのか' : 'ninth day of the month',
         'とおか' : 'tenth day of the month',
         'じゅういちにち' : 'eleventh day of the month',
-        'じゅうににち' : 'twelth day of the month',
+        'じゅうににち' : 'twelfth day of the month',
         'じゅうさんにち' : 'thirteenth day of the month',
         'じゅうよっか' : 'fourteenth day of the month',
         'じゅうごにち' : 'fifteenth day of the month'


### PR DESCRIPTION
Quick typofix, spelling of "twelfth" was wrong.

よろしくお願いします！