### PR TITLE
Remove the word photograph from lesson-17 literacy-5

### DIFF
--- a/lessons/lesson-17/literacy-5/index.html
+++ b/lessons/lesson-17/literacy-5/index.html
@@ -65,7 +65,6 @@
       info : 'Turn to page 302 of Genki II and study the readings and compounds for the kanji 真, 歩, and 野, then match the English expressions to the correct kanji.',
       
       quizlet : {
-        '写真|しゃしん' : 'photograph',
         '真ん中|まんなか' : 'center',
         '～の真上|～のまうえ' : 'right above...',
         '真夜中|まよなか' : 'midnight',


### PR DESCRIPTION
The word is already in lesson-17 literacy-4 and seem to belong over there due to the shared kanjis with other words. It seems to be a mistake that it is also in literacy-5.