### PR TITLE
3rd edition, Lesson 15, Grammar 7, Question 1 written - Added support for 美味しくない

### DIFF
--- a/lessons-3rd/lesson-15/grammar-7/index.html
+++ b/lessons-3rd/lesson-15/grammar-7/index.html
@@ -27,12 +27,12 @@
   </head>
 
   <body>
-    
+
     <header>
       <h1><a href="../../" id="home-link" class="edition-icon third-ed">Genki Study Resources</a></h1>
       <a id="fork-me" href="https://github.com/SethClydesdale/genki-study-resources">Fork Me</a>
     </header>
-    
+
     <div id="content">
       <div id="exercise" class="content-block">
         <div id="quiz-result"></div>
@@ -40,7 +40,7 @@
         <div id="quiz-timer" class="center"></div>
       </div>
     </div>
-    
+
     <footer class="clear">
       <ul class="footer-left">
         <li><a href="../../" id="footer-home">Home</a></li>
@@ -49,12 +49,12 @@
         <li><a href="../../../help/">Help</a></li>
         <li><a href="../../../donate/">Donate</a></li>
       </ul>
-      
+
       <ul class="footer-right">
         <li>Created by <a href="https://github.com/SethClydesdale">Seth Clydesdale</a> and the <a href="https://github.com/SethClydesdale/genki-study-resources/graphs/contributors">GitHub Community</a></li>
       </ul>
     </footer>
-    
+
     <script src="../../../resources/javascript/dragula.min.js"></script>
     <script src="../../../resources/javascript/easytimer.min.js"></script>
     <script src="../../../resources/javascript/exercises/3rd-ed.min.js"></script>
@@ -117,7 +117,7 @@
               '<ruby>去年<rt>きょねん</rt></ruby>の<ruby>春<rt>はる</rt></ruby>に<ruby>会<rt>あ</rt></ruby>う<ruby>人<rt>ひと</rt></ruby>にもう<ruby>一度<rt>いちど</rt></ruby><ruby>会<rt>あ</rt></ruby>いたいです。'
             ]
           },
-          
+
           {
             question : '(よくしゃべります)　<i class="fa">&#xf061;</i>　<ruby><u>人</u><rt>ひと</rt></ruby>とルームメートになりたくないです。',
             answers : [
@@ -158,8 +158,8 @@
             ]
           }
         ],
-        
-        
+
+
         // WRITTEN
         '<div class="example-problem">'+
           '<div class="inner-problem">'+
@@ -167,43 +167,43 @@
             '<i class="fa">&#xf061;</i>　<ruby>田中<rt>たなか</rt></ruby>さんにもらったコーヒーを<ruby>飲<rt>の</rt></ruby>んでみました。'+
           '</div>'+
         '</div>'+
-        
+
         '<div class="count-problems">'+
           '<div class="problem">'+
             '(<ruby>妹<rt>いもうと</rt></ruby>が<ruby>作<rt>つく</rt></ruby>りました)　<i class="fa">&#xf061;</i>　<ruby><u>料理</u><rt>りょうり</rt></ruby>はおいしくないです。<br>'+
-            '{妹が作った料理はおいしくないです|いもうとがつくったりょうりはおいしくないです|' + Genki.getAlts('{妹}が{作}った{料理}はおいしくないです', 'いもうと|つく|りょうり') + 'answer}。'+
+            '{妹が作った料理は美味しくないです|いもうとがつくったりょうりはおいしくないです|' + Genki.getAlts('{妹}が{作}った{料理}は{美味}くないです', 'いもうと|つく|りょうり|おいし') + 'answer}。'+
           '</div>'+
-          
+
           '<div class="problem">'+
             '(<ruby>料理<rt>りょうり</rt></ruby>ができません)　<i class="fa">&#xf061;</i>　<ruby><u>人</u><rt>ひと</rt></ruby>と<ruby>結婚<rt>けっこん</rt></ruby>したくないです。<br>'+
             '{料理ができない人と結婚したくないです|りょうりができない人とけっこんしたくないです|' + Genki.getAlts('{料理}ができない{人}と{結婚}したくないです', 'りょうり|ひと|けっこん') + 'answer}。'+
           '</div>'+
-          
+
           '<div class="problem">'+
             '(<ruby>日本<rt>にほん</rt></ruby>の<ruby>習慣<rt>しゅうかん</rt></ruby>についてよく<ruby>知<rt>し</rt></ruby>っています)　<i class="fa">&#xf061;</i>　<ruby><u>外国人</u><rt>がいこくじん</rt></ruby>を<ruby>探<rt>さが</rt></ruby>しています。<br>'+
             '{日本の習慣についてよく知っている外国人を探しています|にほんのしゅうかんについてよくしっているがいこくじんをさがしています|' + Genki.getAlts('{日本}の{習慣}について{よ}く{知}っている{外国人}を{探}しています', 'にほん|しゅうかん|良|し|がいこくじん|さが') + 'answer}。'+
           '</div>'+
-          
+
           '<div class="problem">'+
             '(<ruby>去年<rt>きょねん</rt></ruby>の<ruby>夏<rt>なつ</rt></ruby>に<ruby>会<rt>あ</rt></ruby>いました)　<i class="fa">&#xf061;</i>　<ruby><u>人</u><rt>ひと</rt></ruby>にもう<ruby>一度<rt>いちど</rt></ruby><ruby>会<rt>あ</rt></ruby>いたいです。<br>'+
             '{去年の夏に会った人にもう一度会いたいです|きょねんのなつにあったひとにもういちどあいたいです|' + Genki.getAlts('{去年}の{夏}に{会}った{人}にもう{一度}{会}いたいです', 'きょねん|なつ|あ|ひと|いちど|あ') + 'answer}。'+
           '</div>'+
-          
+
           '<div class="problem">'+
             '(よくしゃべります)　<i class="fa">&#xf061;</i>　<ruby><u>人</u><rt>ひと</rt></ruby>とルームメートになりたくないです。<br>'+
             '{よくしゃべる人とルームメートになりたくないです|よくしゃべるひととルームメートになりたくないです|' + Genki.getAlts('{よ}く{しゃべ}る{人}とルームメートになりたくないです', '良|喋|ひと') + 'answer}。'+
           '</div>'+
-          
+
           '<div class="problem">'+
             '(おじさんが<ruby>働<rt>はたら</rt></ruby>いています)　<i class="fa">&#xf061;</i>　<ruby><u>会社</u><rt>かいしゃ</rt></ruby>はこの<ruby>建物<rt>たてもの</rt></ruby>の<ruby>中<rt>なか</rt></ruby>にあります。<br>'+
             '{おじさんが働いている会社はこの建物の中にあります|おじさんがはたらいているかいしゃはこのたてもののなかにあります|' + Genki.getAlts('おじさんが{働}いている{会社}はこの{建物}の{中}にあります', 'はたら|かいしゃ|たてもの|なか') + 'answer}。'+
           '</div>'+
-          
+
           '<div class="problem">'+
             '(<ruby>温泉<rt>おんせん</rt></ruby>があります)　<i class="fa">&#xf061;</i>　<ruby>冬休<rt>ふゆやす</rt></ruby>みに<ruby><u>旅館</u><rt>りょかん</rt></ruby>に<ruby>泊<rt>と</rt></ruby>まろうと<ruby>思<rt>おも</rt></ruby>っています。<br>'+
             '{冬休みに温泉がある旅館に泊まろうと思っています|ふゆやすみにおんせんがあるりょかんにとまろうとおもっています|' + Genki.getAlts('{冬休}みに{温泉}がある{旅館}に{泊}まろうと{思}っています', 'ふゆやす|おんせん|りょかん|と|おも') + 'answer}。'+
           '</div>'+
-          
+
           '<div class="problem">'+
             '(アメリカに<ruby>留学<rt>りゅうがく</rt></ruby>したことがあります)　<i class="fa">&#xf061;</i>　<ruby>留学<rt>りゅうがく</rt></ruby>に<ruby>興味<rt>きょうみ</rt></ruby>があるんですが、<ruby><u>学生</u><rt>がくせい</rt></ruby>を知っていますか。<br>'+
             '{留学に興味があるんですが、アメリカに留学したことがある学生を知っていますか|りゅうがくにきょうみがあるんですが、アメリカにりゅうがくしたことがあるがくせいを知っていますか|' + Genki.getAlts('{留学}に{興味}があるんですが、アメリカに{留学}したことがある{学生}を{知}っていますか', 'りゅうがく|きょうみ|りゅうがく|がくせい|し') + 'answer}。'+


### PR DESCRIPTION
This PR updates the aforementioned question in the associated exercise, lesson and edition by adding support for the Kanji of tasty.

## Before
おいしくない was allowed, but 美味しくない was not allowed.

<img width="558" alt="before" src="https://github.com/SethClydesdale/genki-study-resources/assets/568153/5cc7cd01-3a82-4925-baad-58575c965f7b">

## Now
Both are allowed. I tested both 美味しくない and おいしくない and both were considered correct.

<img width="352" alt="after" src="https://github.com/SethClydesdale/genki-study-resources/assets/568153/e5cae8f1-f154-4d5f-bd89-8a2a57846f3d">

References #257
