### PR TITLE
お菓子 hiragana

### DIFF
--- a/lessons-3rd/lesson-20/grammar-10/index.html
+++ b/lessons-3rd/lesson-20/grammar-10/index.html
@@ -224,7 +224,7 @@
             
             '<div class="problem">'+
               'A snack called Pocky.<br>'+
-              '{ポッキーというお菓子|ポッキーというお菓子|answer}。'+
+              '{ポッキーというお菓子|ポッキーというおかし|answer}。'+
             '</div>'+
             
             '<div class="problem">'+


### PR DESCRIPTION
Lesson 20, Grammar 10.

It seems that only the kanji version of snack is accepted.
![image](https://github.com/SethClydesdale/genki-study-resources/assets/53652695/9d4d82c2-e66b-463a-9afa-abc42806f5d5)

This can be fixed by using the hiragana for the alternative answer (which wrongly used the kanji instead)
![image](https://github.com/SethClydesdale/genki-study-resources/assets/53652695/980b32fa-2cf9-43f7-b3be-e4fd3f442c80)
