### PR TITLE
fix: alts not accepted

### DIFF
--- a/lessons-3rd/lesson-7/workbook-5/index.html
+++ b/lessons-3rd/lesson-7/workbook-5/index.html
@@ -109,7 +109,7 @@
         
         '<div class="problem"><ruby>私<rt>わたし</rt></ruby>の<ruby>猫<rt>ねこ</rt></ruby>は{%(とても/すごく)小さくてかわいいです|%(とても/すごく)ちいさくてかわいいです|answer}。</div>'+
         
-        '<div class="problem"><ruby>私<rt>わたし</rt></ruby>の<ruby>部屋<rt>へや</rt></ruby>は{%(とても/すごく)きれいで新しいです|%(とても/すごく)きれいであたらしいです|answer' + Genki.getAlts('{とても}{きれい}で{新}しいです', 'すごく|綺麗|あたら') + '}。</div>'+
+        '<div class="problem"><ruby>私<rt>わたし</rt></ruby>の<ruby>部屋<rt>へや</rt></ruby>は{%(とても/すごく)きれいで新しいです|%(とても/すごく)きれいであたらしいです|' + Genki.getAlts('{とても}{きれい}で{新}しいです', 'すごく|綺麗|あたら') + 'answer}。</div>'+
         
         '<div class="problem">このお<ruby>寺<rt>てら</rt></ruby>は{古くておもしろいです|ふるくておもしろいです|' + Genki.getAlts('{古}くて{面白}いです', 'ふる|おもしろ') + 'answer}。</div>'+
         


### PR DESCRIPTION
In Lesson 7, Workbook 5, alternative answers do not seem to be accepted for Q4 of the first section.

![image](https://github.com/user-attachments/assets/804176e2-66bf-4363-9bdd-c97ff0df6dab)

Fixed by moving the `answer` suffix to the end of the sentence.

![image](https://github.com/user-attachments/assets/2d703fdd-a26b-4a9d-a0cc-89816e71ca48)
