### PR TITLE
fix: older sister hiragana

### DIFF
--- a/lessons-3rd/lesson-16/workbook-2/index.html
+++ b/lessons-3rd/lesson-16/workbook-2/index.html
@@ -69,7 +69,7 @@
         '<p class="sectionDesc3rd"><span class="sectionNumber3rd">I</span>Describe the situations, using ～てあげる, ～てくれる, and ～てもらう.</p>'+
         '<div class="problem">'+
           'My older sister sometimes lends me her car.<br>'+
-          '{姉は時々%(私に/)車を貸してくれます|%(私は/)時々姉に車を貸してもらいます|' + Genki.getAlts('{姉}は{時々}{私}に{車}を{貸}してくれます', 'いもうと|ときどき|わたし|くるま|か') + Genki.getAlts('{姉}は{時々}{車}を{貸}してくれます', 'いもうと|ときどき|くるま|か') + Genki.getAlts('{私}は{時々}{姉}に{車}を{貸}してもらいます', 'わたし|ときどき|いもうと|くるま|か') + Genki.getAlts('{時々}{姉}に{車}を{貸}してもらいます', 'ときどき|いもうと|くるま|か') + 'answer;width:500}。'+
+          '{姉が時々%(私に/)車を貸してくれます|%(私は/)時々姉に車を貸してもらいます|' + Genki.getAlts('{姉}が{時々}{私}に{車}を{貸}してくれます', 'あね|ときどき|わたし|くるま|か') + Genki.getAlts('{姉}が{時々}{車}を{貸}してくれます', 'あね|ときどき|くるま|か') + Genki.getAlts('{私}は{時々}{姉}に{車}を{貸}してもらいます', 'わたし|ときどき|あね|くるま|か') + Genki.getAlts('{時々}{姉}に{車}を{貸}してもらいます', 'ときどき|あね|くるま|か') + 'answer;width:500}。'+
         '</div>'+
         
         '<div class="problem">'+


### PR DESCRIPTION
Hiragana for younger sister is used in place of older sister kanji. Consequently, the wrong answer is marked as correct.

![image](https://github.com/user-attachments/assets/2a2ea540-19ab-4507-b0d8-0d8ea72aa7b9)

This fix uses the correct hiragana and also changes the `は` particle to `が` which is usually used for `てくれる`.

![image](https://github.com/user-attachments/assets/3e9f6525-0c12-4a07-b6fc-76e92e15a3da)

Change in particle is inferred from examples in textbook. However, I am not sure if this is what is expected. Additionally, the other answers for the same section continue to use `は` and is not changed in this PR.