### PR TITLE
fix: add hiragana answer for 好き

### DIFF
--- a/lessons-3rd/lesson-9/vocab-8/index.html
+++ b/lessons-3rd/lesson-9/vocab-8/index.html
@@ -80,7 +80,7 @@
       
       quizlet : {
         '赤いかばん|あかいかばん' : 'red bag',
-        '赤がいちばん好きです。|あかがいちばん好きです。' : 'I like red the best.',
+        '赤がいちばん好きです。|あかがいちばんすきです。' : 'I like red the best.',
         '緑のセーター／グリーンのセーター|みどりのセーター／グリーンのセーター' : 'green sweater',
         '顔が青いですね。|かおがあおいですね。' : 'You look pale.',
         '白黒の写真|しろくろのしゃしん' : 'black and white picture',


### PR DESCRIPTION
Currently, the full hiragana answer is not accepted because 好き is provided in kanji.

![image](https://github.com/user-attachments/assets/6db3d497-2b4f-4cfa-98dc-8571a390e216)

This PR allows the full hiragana answer to be marked as correct.

![image](https://github.com/user-attachments/assets/a98dc502-d5bd-41f1-9f73-88abfdf00c59)
