### PR TITLE
fix: use katakana for card

### DIFF
--- a/lessons-3rd/lesson-10/vocab-6/index.html
+++ b/lessons-3rd/lesson-10/vocab-6/index.html
@@ -92,7 +92,7 @@
         '一号車|いちごうしゃ' : 'Car No.1',
         '往復|おうふく' : 'round trip',
         '片道|かたみち' : 'one way',
-        '交通系ICカード|こうつうけいICかーど' : 'rechargeable card such as Suica, Icoca, Pasmo, etc.'
+        '交通系ICカード|こうつうけいICカード' : 'rechargeable card such as Suica, Icoca, Pasmo, etc.'
       }
     });</script>
   </body>


### PR DESCRIPTION
Card is usually written in katakana: カード, so i recommend we use this even for the hiragana answer.

This follows the standard for other words such as メール、メガネ, etc...