### PR TITLE
fix: accept hiragana for 円 character in hiragana answer

### DIFF
--- a/lessons-3rd/lesson-13/vocab-8/index.html
+++ b/lessons-3rd/lesson-13/vocab-8/index.html
@@ -81,7 +81,7 @@
       quizlet : {
         '口座を開きたいんですが。|こうざをひらきたいんですが。' : 'I would like to open an account.',
         '口座を閉じたいんですが。|こうざをとじたいんですが。' : 'I would like to close an account.',
-        'ドルを円にかえてください。|ドルを円にかえてください。' : 'Please change dollars into yen.',
+        'ドルを円にかえてください。|ドルをえんにかえてください。' : 'Please change dollars into yen.',
         '口座にお金を振り込みたいんですが。|こうざにおかねをふりこみたいんですが。' : 'I would like to deposit money into the account.',
         '一万円札を千円札十枚に両替できますか。|いちまんえんさつをせんえんさつじゅうまいにりょうがえできますか。' : 'Can you change a 10,000-yen bill into ten 1,000-yen bills?',
         'お金をおろします。|おかねをおろします。' : 'I will withdraw money.'


### PR DESCRIPTION
Hiragana answer uses 円 in kanji form.

![image](https://github.com/user-attachments/assets/82f443c9-2734-47ac-a233-384f8ae51ea4)

We should accept the hiragana form.

![image](https://github.com/user-attachments/assets/1a5e3469-98ea-4426-846d-a86d7500ee95)
